### PR TITLE
Store next_index in local db

### DIFF
--- a/libzkbob-rs-node/src/merkle.rs
+++ b/libzkbob-rs-node/src/merkle.rs
@@ -26,7 +26,7 @@ pub fn merkle_new(mut cx: FunctionContext) -> JsResult<BoxedMerkleTree> {
     let path_js = cx.argument::<JsString>(0)?;
     let path = path_js.value(&mut cx);
     let inner =
-        NativeMerkleTree::new_native(&Default::default(), &path, POOL_PARAMS.clone()).unwrap();
+        NativeMerkleTree::new_native(Default::default(), &path, POOL_PARAMS.clone()).unwrap();
 
     Ok(cx.boxed(RwLock::new(MerkleTree { inner })))
 }


### PR DESCRIPTION
Now, every `next_index` update is backed by local db. It speeds up and simplifies the procedure of restoring a tree