### PR TITLE
Add rollback binding

### DIFF
--- a/libzkbob-rs-node/Cargo.toml
+++ b/libzkbob-rs-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzkbob-rs-node"
-version = "0.1.26"
+version = "0.1.27"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs-node/index.d.ts
+++ b/libzkbob-rs-node/index.d.ts
@@ -24,6 +24,7 @@ declare class MerkleTree {
         new_hashes_left_index: number,
         new_hashes_right_index: number,
     ): any;
+    rollback(index: number): void;
 }
 
 declare class TxStorage {

--- a/libzkbob-rs-node/index.js
+++ b/libzkbob-rs-node/index.js
@@ -57,6 +57,10 @@ class MerkleTree {
             new_hashes_right_index,
         )
     }
+
+    rollback(index) {
+        return zp.merkleRollback(this.inner, index)
+    }
 }
 
 class TxStorage {

--- a/libzkbob-rs-node/package-lock.json
+++ b/libzkbob-rs-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libzkbob-rs-node",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "libzkbob-rs-node",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/libzkbob-rs-node/package.json
+++ b/libzkbob-rs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libzkbob-rs-node",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Neon version of libzkbob-rs",
   "main": "index.js",
   "types": "index.d.ts",

--- a/libzkbob-rs-node/src/lib.rs
+++ b/libzkbob-rs-node/src/lib.rs
@@ -62,6 +62,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     )?;
     cx.export_function("merkleGetAllNodes", merkle::merkle_get_all_nodes)?;
     cx.export_function("merkleGetVirtualNode", merkle::merkle_get_virtual_node)?;
+    cx.export_function("merkleRollback", merkle::merkle_rollback)?;
 
     cx.export_function("txStorageNew", storage::tx_storage_new)?;
     cx.export_function("txStorageAdd", storage::tx_storage_add)?;

--- a/libzkbob-rs-node/src/merkle.rs
+++ b/libzkbob-rs-node/src/merkle.rs
@@ -101,7 +101,7 @@ pub fn merkle_get_leaf_proof(mut cx: FunctionContext) -> JsResult<JsValue> {
 
 pub fn merkle_get_commitment_proof(mut cx: FunctionContext) -> JsResult<JsValue> {
     let tree = cx.argument::<BoxedMerkleTree>(0)?;
-    let index: u64 = {
+    let index = {
         let num = cx.argument::<JsNumber>(1)?;
         num.value(&mut cx) as u64
     };
@@ -129,11 +129,11 @@ pub fn merkle_get_root(mut cx: FunctionContext) -> JsResult<JsValue> {
 
 pub fn merkle_get_node(mut cx: FunctionContext) -> JsResult<JsValue> {
     let tree = cx.argument::<BoxedMerkleTree>(0)?;
-    let height: u32 = {
+    let height = {
         let num = cx.argument::<JsNumber>(1)?;
         num.value(&mut cx) as u32
     };
-    let index: u64 = {
+    let index = {
         let num = cx.argument::<JsNumber>(2)?;
         num.value(&mut cx) as u64
     };
@@ -207,4 +207,17 @@ pub fn merkle_get_virtual_node(mut cx: FunctionContext) -> JsResult<JsValue> {
     let result = neon_serde::to_value(&mut cx, &node).unwrap();
 
     Ok(result)
+}
+
+pub fn merkle_rollback(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let tree = cx.argument::<BoxedMerkleTree>(0)?;
+    let rollback_index = {
+        let num = cx.argument::<JsNumber>(1)?;
+        num.value(&mut cx) as u64
+    };
+
+    let mut a = tree.write().unwrap();
+    a.inner.rollback(rollback_index);
+
+    Ok(cx.undefined())
 }


### PR DESCRIPTION
Add `rollback` function JS binding. Required for relayer optimistic state recovery in case of failed tx