### PR TITLE
Fix/multinote tx bug

### DIFF
--- a/libzkbob-rs-wasm/scripts/build
+++ b/libzkbob-rs-wasm/scripts/build
@@ -16,6 +16,9 @@ function build () {
   # Remove invalid typings
   sed -i.bak -E '/BroccoliDestroyInstance/d' $PARENT_DIR/$1/libzkbob_rs_wasm.d.ts
   sed -i.bak -E '/BroccoliDestroyInstance/d' $PARENT_DIR/$1/libzkbob_rs_wasm_bg.wasm.d.ts
+  
+  rm $PARENT_DIR/$1/libzkbob_rs_wasm_bg.wasm.d.ts
+  
   # Patch package.json, since wasm-pack doesn't allow renaming packages
   sed -i.bak -E "s/\"name\": \"libzkbob-rs-wasm\"/\"name\": \"libzkbob-rs-wasm-$1\"/g" $PARENT_DIR/$1/package.json
   # Add workerHelpers.js in package.json

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -239,7 +239,7 @@ where
             let next_by_optimistic_leaf = extra_state.new_leafs
                 .last()
                 .map(|leafs| {
-                    (((leafs.0 + (leafs.1.len() as u64)) >> constants::OUTPLUSONELOG) + 1) << constants::OUTPLUSONELOG
+                    (((leafs.0 + (leafs.1.len() as u64) - 1) >> constants::OUTPLUSONELOG) + 1) << constants::OUTPLUSONELOG
                 });
             let next_by_optimistic_commitment = extra_state.new_commitments
                 .last()

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -320,7 +320,7 @@ where
 
         let (num_real_out_notes, out_notes): (_, SizedVec<_, { constants::OUT }>) =
             if let TxType::Transfer(_, _, outputs) = &tx {
-                if outputs.len() >= constants::OUT {
+                if outputs.len() > constants::OUT {
                     return Err(CreateTxError::TooManyOutputs {
                         max: constants::OUT,
                         got: outputs.len(),


### PR DESCRIPTION
Fix issues related to Merkle tree building for multinote transactions:
- `add_leafs_and_commitments` function: fix virtual_nodes building, fix next_index calculation for full tx (with 127 notes)
- `get_virtual_subtree` function: the similar changes with `add_leafs_and_commitments`
- fix error condition on transfer creation which prevent creating transfer with 127 notes

**It's strongly need to test the changes introduced by this pull request!**

To test this branch you could use the following toolchain:
- `zkbob-client-js` -> branch [feature/multinote-tx](https://github.com/zkBob/zkbob-client-js/tree/feature/multinote-tx)
- `zkbob-console` -> branch [feature/multinote-tx](https://github.com/zkBob/zkbob-console/tree/feature/multinote-tx)

To build multinote transaction use `transfer-shielded-multinote shielded_address note_amount notes_count` command in the console, e.g.:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/1415489/196289786-4a2af107-88a4-4afa-89b6-316fcb5559c8.png">
