### PR TITLE
Add Web Workers support in kvdb-web (#26)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,11 @@ members = [
     "libzkbob-rs-wasm",
     "libzkbob-rs",
     "libzkbob-rs-node",
+    "libs/kvdb-web",
 ]
 
 default-members = [
     "libzkbob-rs",
     "libzkbob-rs-node",
+    "libs/kvdb-web",
 ]

--- a/libs/kvdb-web/CHANGELOG.md
+++ b/libs/kvdb-web/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+The format is based on [Keep a Changelog].
+
+[Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
+
+## [Unreleased]
+
+## [0.9.0] - 2021-01-27
+### Breaking
+- Updated `kvdb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `kvdb-memorydb` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+- Updated `parity-util-mem` to 0.9. [#510](https://github.com/paritytech/parity-common/pull/510)
+
+## [0.8.0] - 2021-01-05
+### Breaking
+- Updated dependencies. [#470](https://github.com/paritytech/parity-common/pull/470)
+
+## [0.7.0] - 2020-07-06
+- Updated `kvdb` to 0.7.0 [#404](https://github.com/paritytech/parity-common/pull/404)
+
+## [0.6.0] - 2020-05-05
+### Breaking
+- Updated to the new `kvdb` interface. [#313](https://github.com/paritytech/parity-common/pull/313)
+
+## [0.5.0] - 2020-03-16
+- License changed from GPL3 to dual MIT/Apache2. [#342](https://github.com/paritytech/parity-common/pull/342)
+- Updated dependencies. [#361](https://github.com/paritytech/parity-common/pull/361)
+
+## [0.4.0] - 2019-02-05
+- Bump parking_lot to 0.10. [#332](https://github.com/paritytech/parity-common/pull/332)
+
+## [0.3.1] - 2019-01-06
+- Updated features and feature dependencies. [#307](https://github.com/paritytech/parity-common/pull/307)
+
+## [0.3.0] - 2019-01-04
+- Updated to new `kvdb` and `parity-util-mem` versions. [#299](https://github.com/paritytech/parity-common/pull/299)
+
+## [0.2.0] - 2019-12-19
+### Changed
+- Default column support removed from the API
+  - Column argument type changed from `Option<u32>` to `u32`
+  - Migration `None` -> unsupported, `Some(0)` -> `0`, `Some(1)` -> `1`, etc.
+
+## [0.1.1] - 2019-10-24
+### Dependencies
+- Updated dependencies. [#239](https://github.com/paritytech/parity-common/pull/239)

--- a/libs/kvdb-web/Cargo.toml
+++ b/libs/kvdb-web/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "kvdb-web"
+version = "0.9.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+repository = "https://github.com/paritytech/parity-common"
+description = "A key-value database for use in browsers"
+documentation = "https://docs.rs/kvdb-web/"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]
+wasm-bindgen = "0.2.69"
+js-sys = "0.3.46"
+kvdb = { version = "0.9"}
+kvdb-memorydb = { version = "0.9" }
+futures = "0.3.8"
+log = "0.4.11"
+send_wrapper = "0.5.0"
+parity-util-mem = { version = "0.9", default-features = false }
+# TODO: https://github.com/paritytech/parity-common/issues/479
+# This is hack to enable `wasm-bindgen` feature of `parking_lot` in other dependencies.
+# Thus, it's not direct dependency and do not remove until a proper fix exists.
+parking_lot = { version = "0.11.1", features = ["wasm-bindgen"] }
+
+[dependencies.web-sys]
+version = "0.3.46"
+features = [
+	'console',
+	'Window',
+	'IdbFactory',
+	'IdbDatabase',
+	'IdbTransaction',
+	'IdbTransactionMode',
+	'IdbOpenDbRequest',
+	'IdbRequest',
+	'IdbObjectStore',
+	'Event',
+	'EventTarget',
+	'IdbCursor',
+	'IdbCursorWithValue',
+	'IdbKeyRange',
+	'DomStringList',
+	'WorkerGlobalScope',
+]
+
+[dev-dependencies]
+console_log = "0.2.0"
+kvdb-shared-tests = { version = "0.7" }
+wasm-bindgen-test = "0.3.19"
+wasm-bindgen-futures = "0.4.19"

--- a/libs/kvdb-web/src/error.rs
+++ b/libs/kvdb-web/src/error.rs
@@ -1,0 +1,45 @@
+// Copyright 2020 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Errors that can occur when working with IndexedDB.
+
+use std::fmt;
+
+/// An error that occurred when working with IndexedDB.
+#[derive(Clone, PartialEq, Debug)]
+pub enum Error {
+	/// Accessing a Window or Worker Global Scope has failed.	
+	GlobalScopeNotAvailable,
+	/// IndexedDB is not supported by your browser.
+	NotSupported(String),
+	/// This enum may grow additional variants,
+	/// so this makes sure clients don't count on exhaustive matching.
+	/// (Otherwise, adding a new variant could break existing code.)
+	#[doc(hidden)]
+	__Nonexhaustive,
+}
+
+impl std::error::Error for Error {
+	fn description(&self) -> &str {
+		match *self {
+			Error::GlobalScopeNotAvailable => "Accessing a Window or Worker Global Scope has failed",
+			Error::NotSupported(_) => "IndexedDB is not supported by your browser",
+			Error::__Nonexhaustive => unreachable!(),
+		}
+	}
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match *self {
+			Error::GlobalScopeNotAvailable => write!(f, "Accessing a Window or Worker Global Scope has failed"),
+			Error::NotSupported(ref err) => write!(f, "IndexedDB is not supported by your browser: {}", err,),
+			Error::__Nonexhaustive => unreachable!(),
+		}
+	}
+}

--- a/libs/kvdb-web/src/global.rs
+++ b/libs/kvdb-web/src/global.rs
@@ -1,0 +1,27 @@
+use wasm_bindgen::{JsValue, JsCast};
+use web_sys::{Window, WorkerGlobalScope, IdbFactory};
+
+pub enum Global {
+    Window(Window),
+    WorkerGlobalScope(WorkerGlobalScope),
+}
+
+impl Global {
+    pub fn indexed_db(&self) -> Result<Option<IdbFactory>, JsValue> {
+        match self {
+            Global::Window(window) => window.indexed_db(),
+            Global::WorkerGlobalScope(scope) => scope.indexed_db(),
+        }   
+    }
+}
+
+pub fn self_() -> Result<Global, JsValue> {
+    let global = js_sys::global();
+    // how to properly detect this in wasm_bindgen?
+    if js_sys::eval("typeof WorkerGlobalScope !== 'undefined'")?.as_bool().unwrap() {
+        Ok(global.dyn_into::<WorkerGlobalScope>().map(Global::WorkerGlobalScope)?)
+    }
+    else {
+        Ok(global.dyn_into::<Window>().map(Global::Window)?)
+    }
+}

--- a/libs/kvdb-web/src/indexed_db.rs
+++ b/libs/kvdb-web/src/indexed_db.rs
@@ -1,0 +1,239 @@
+// Copyright 2020 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Utility functions to interact with IndexedDB browser API.
+
+use js_sys::{Array, ArrayBuffer, Uint8Array};
+use wasm_bindgen::{closure::Closure, JsCast, JsValue};
+use web_sys::{Event, IdbCursorWithValue, IdbDatabase, IdbKeyRange, IdbOpenDbRequest, IdbRequest, IdbTransactionMode};
+
+use futures::channel;
+use futures::prelude::*;
+
+use kvdb::{DBOp, DBTransaction};
+
+use log::{debug, warn};
+use std::ops::Deref;
+
+use crate::error::Error;
+use crate::global;
+
+pub struct IndexedDB {
+	pub version: u32,
+	pub columns: u32,
+	pub inner: super::SendWrapper<IdbDatabase>,
+}
+
+/// Opens the IndexedDB with the given name, version and the specified number of columns
+/// (including the default one).
+pub fn open(name: &str, version: Option<u32>, columns: u32) -> impl Future<Output = Result<IndexedDB, Error>> {
+	let (tx, rx) = channel::oneshot::channel::<IndexedDB>();
+
+	let global =  match global::self_() {
+		Ok(global) => global,
+		Err(_) => return future::Either::Right(future::err(Error::GlobalScopeNotAvailable))
+	};
+    let idb_factory = global.indexed_db();
+
+	let idb_factory = match idb_factory {
+		Ok(idb_factory) => idb_factory.expect("We can't get a null pointer back; qed"),
+		Err(err) => return future::Either::Right(future::err(Error::NotSupported(format!("{:?}", err)))),
+	};
+
+	let open_request = match version {
+		Some(version) => idb_factory.open_with_u32(name, version).expect("TypeError is not possible with Rust; qed"),
+		None => idb_factory.open(name).expect("TypeError is not possible with Rust; qed"),
+	};
+
+	try_create_missing_stores(&open_request, columns, version);
+
+	let on_success = Closure::once(move |event: &Event| {
+		// Extract database handle from the event
+		let target = event.target().expect("Event should have a target; qed");
+		let req = target.dyn_ref::<IdbRequest>().expect("Event target is IdbRequest; qed");
+
+		let result = req.result().expect("IndexedDB.onsuccess should have a valid result; qed");
+		assert!(result.is_instance_of::<IdbDatabase>());
+
+		let db = IdbDatabase::from(result);
+		// JS returns version as f64
+		let version = db.version().round() as u32;
+		let columns = db.object_store_names().length();
+
+		// errors if the receiving end was dropped before this call
+		let _ = tx.send(IndexedDB { version, columns, inner: super::SendWrapper::new(db) });
+	});
+	open_request.set_onsuccess(Some(on_success.as_ref().unchecked_ref()));
+	on_success.forget();
+
+	future::Either::Left(rx.then(|r| future::ok(r.expect("Sender isn't dropped; qed"))))
+}
+
+fn store_name(num: u32) -> String {
+	format!("col{}", num)
+}
+
+// Returns js objects representing store names for each column
+fn store_names_js(columns: u32) -> Array {
+	let column_names = (0..columns).map(store_name);
+
+	let js_array = Array::new();
+	for name in column_names {
+		js_array.push(&JsValue::from(name));
+	}
+
+	js_array
+}
+
+fn try_create_missing_stores(req: &IdbOpenDbRequest, columns: u32, version: Option<u32>) {
+	let on_upgradeneeded = Closure::once(move |event: &Event| {
+		debug!("Upgrading or creating the database to version {:?}, columns {}", version, columns);
+		// Extract database handle from the event
+		let target = event.target().expect("Event should have a target; qed");
+		let req = target.dyn_ref::<IdbRequest>().expect("Event target is IdbRequest; qed");
+		let result = req.result().expect("IdbRequest should have a result; qed");
+		let db: &IdbDatabase = result.unchecked_ref();
+
+		let previous_columns = db.object_store_names().length();
+		debug!("Previous version: {}, columns {}", db.version(), previous_columns);
+
+		for name in (previous_columns..=columns).map(store_name) {
+			let res = db.create_object_store(name.as_str());
+			if let Err(err) = res {
+				debug!("error creating object store {}: {:?}", name, err);
+			}
+		}
+	});
+
+	req.set_onupgradeneeded(Some(on_upgradeneeded.as_ref().unchecked_ref()));
+	on_upgradeneeded.forget();
+}
+
+/// Commit a transaction to the IndexedDB.
+pub fn idb_commit_transaction(idb: &IdbDatabase, txn: &DBTransaction, columns: u32) -> impl Future<Output = ()> {
+	let store_names_js = store_names_js(columns);
+
+	// Create a transaction
+	let mode = IdbTransactionMode::Readwrite;
+	let idb_txn = idb
+		.transaction_with_str_sequence_and_mode(&store_names_js, mode)
+		.expect("The provided mode and store names are valid; qed");
+
+	// Open object stores (columns)
+	let object_stores = (0..columns)
+		.map(|n| {
+			idb_txn
+				.object_store(store_name(n).as_str())
+				.expect("Object stores were created in try_create_object_stores; qed")
+		})
+		.collect::<Vec<_>>();
+
+	for op in &txn.ops {
+		match op {
+			DBOp::Insert { col, key, value } => {
+				let column = *col as usize;
+				// Convert rust bytes to js arrays
+				let key_js = Uint8Array::from(key.as_ref());
+				let val_js = Uint8Array::from(value.as_ref());
+
+				// Insert key/value pair into the object store
+				let res = object_stores[column].put_with_key(val_js.as_ref(), key_js.as_ref());
+				if let Err(err) = res {
+					warn!("error inserting key/values into col_{}: {:?}", column, err);
+				}
+			}
+			DBOp::Delete { col, key } => {
+				let column = *col as usize;
+				// Convert rust bytes to js arrays
+				let key_js = Uint8Array::from(key.as_ref());
+
+				// Delete key/value pair from the object store
+				let res = object_stores[column].delete(key_js.as_ref());
+				if let Err(err) = res {
+					warn!("error deleting key from col_{}: {:?}", column, err);
+				}
+			}
+			DBOp::DeletePrefix { col, prefix } => {
+				let column = *col as usize;
+				// Convert rust bytes to js arrays
+				let prefix_js_start = Uint8Array::from(prefix.as_ref());
+				let prefix_js_end = Uint8Array::from(prefix.as_ref());
+
+				let range = IdbKeyRange::bound(prefix_js_start.as_ref(), prefix_js_end.as_ref())
+					.expect("Starting and ending at same value is valid bound; qed");
+				let res = object_stores[column].delete(range.as_ref());
+				if let Err(err) = res {
+					warn!("error deleting prefix from col_{}: {:?}", column, err);
+				}
+			}
+		}
+	}
+
+	let (tx, rx) = channel::oneshot::channel::<()>();
+
+	let on_complete = Closure::once(move || {
+		let _ = tx.send(());
+	});
+	idb_txn.set_oncomplete(Some(on_complete.as_ref().unchecked_ref()));
+	on_complete.forget();
+
+	let on_error = Closure::once(move || {
+		warn!("Failed to commit a transaction to IndexedDB");
+	});
+	idb_txn.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+	on_error.forget();
+
+	rx.map(|_| ())
+}
+
+/// Returns a cursor to a database column with the given column number.
+pub fn idb_cursor(idb: &IdbDatabase, col: u32) -> impl Stream<Item = (Vec<u8>, Vec<u8>)> {
+	// TODO: we could read all the columns in one db transaction
+	let store_name = store_name(col);
+	let store_name = store_name.as_str();
+	let txn = idb.transaction_with_str(store_name).expect("The stores were created on open: {}; qed");
+
+	let store = txn.object_store(store_name).expect("Opening a store shouldn't fail; qed");
+	let cursor = store.open_cursor().expect("Opening a cursor shouldn't fail; qed");
+
+	let (tx, rx) = channel::mpsc::unbounded();
+
+	let on_cursor = Closure::wrap(Box::new(move |event: &Event| {
+		// Extract the cursor from the event
+		let target = event.target().expect("on_cursor should have a target; qed");
+		let req = target.dyn_ref::<IdbRequest>().expect("target should be IdbRequest; qed");
+		let result = req.result().expect("IdbRequest should have a result; qed");
+		let cursor: &IdbCursorWithValue = result.unchecked_ref();
+
+		if let (Ok(key), Ok(value)) = (cursor.deref().key(), cursor.value()) {
+			let k: &ArrayBuffer = key.unchecked_ref();
+			let v: &Uint8Array = value.unchecked_ref();
+
+			// Copy js arrays into rust `Vec`s
+			let mut kv = vec![0u8; k.byte_length() as usize];
+			let mut vv = vec![0u8; v.byte_length() as usize];
+			Uint8Array::new(k).copy_to(&mut kv[..]);
+			v.copy_to(&mut vv[..]);
+
+			if let Err(e) = tx.unbounded_send((kv, vv)) {
+				warn!("on_cursor: error sending to a channel {:?}", e);
+			}
+			if let Err(e) = cursor.deref().continue_() {
+				warn!("cursor advancement has failed {:?}", e);
+			}
+		} else {
+			// we're done
+			tx.close_channel();
+		}
+	}) as Box<dyn FnMut(&Event)>);
+
+	cursor.set_onsuccess(Some(on_cursor.as_ref().unchecked_ref()));
+	on_cursor.forget();
+
+	rx
+}

--- a/libs/kvdb-web/src/lib.rs
+++ b/libs/kvdb-web/src/lib.rs
@@ -1,0 +1,129 @@
+// Copyright 2020 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A key-value database for use in browsers
+//!
+//! Writes data both into memory and IndexedDB, reads the whole database in memory
+//! from the IndexedDB on `open`.
+
+#![deny(missing_docs)]
+
+mod error;
+mod indexed_db;
+mod global;
+
+use kvdb::{DBTransaction, DBValue};
+use kvdb_memorydb::{self as in_memory, InMemory};
+use send_wrapper::SendWrapper;
+use std::io;
+
+pub use error::Error;
+pub use kvdb::KeyValueDB;
+
+use futures::prelude::*;
+
+use web_sys::IdbDatabase;
+
+/// Database backed by both IndexedDB and in memory implementation.
+pub struct Database {
+	name: String,
+	version: u32,
+	columns: u32,
+	in_memory: InMemory,
+	indexed_db: SendWrapper<IdbDatabase>,
+}
+
+// TODO: implement when web-based implementation need memory stats
+parity_util_mem::malloc_size_of_is_0!(Database);
+
+impl Database {
+	/// Opens the database with the given name,
+	/// and the specified number of columns (not including the default one).
+	pub async fn open(name: String, columns: u32) -> Result<Database, error::Error> {
+		let name_clone = name.clone();
+		// let's try to open the latest version of the db first
+		let db = indexed_db::open(name.as_str(), None, columns).await?;
+
+		// If we need more column than the latest version has,
+		// then bump the version (+ 1 for the default column).
+		// In order to bump the version, we close the database
+		// and reopen it with a higher version than it was opened with previously.
+		// cf. https://github.com/paritytech/parity-common/pull/202#discussion_r321221751
+		let db = if columns + 1 > db.columns {
+			let next_version = db.version + 1;
+			drop(db);
+			indexed_db::open(name.as_str(), Some(next_version), columns).await?
+		} else {
+			db
+		};
+		// populate the in_memory db from the IndexedDB
+		let indexed_db::IndexedDB { version, inner, .. } = db;
+		let in_memory = in_memory::create(columns);
+		// read the columns from the IndexedDB
+		for column in 0..columns {
+			let mut txn = DBTransaction::new();
+			let mut stream = indexed_db::idb_cursor(&*inner, column);
+			while let Some((key, value)) = stream.next().await {
+				txn.put_vec(column, key.as_ref(), value);
+			}
+			// write each column into memory
+			in_memory.write(txn).expect("writing in memory always succeeds; qed");
+		}
+		Ok(Database { name: name_clone, version, columns, in_memory, indexed_db: inner })
+	}
+
+	/// Get the database name.
+	pub fn name(&self) -> &str {
+		self.name.as_str()
+	}
+
+	/// Get the database version.
+	pub fn version(&self) -> u32 {
+		self.version
+	}
+}
+
+impl Drop for Database {
+	fn drop(&mut self) {
+		self.indexed_db.close();
+	}
+}
+
+impl KeyValueDB for Database {
+	fn get(&self, col: u32, key: &[u8]) -> io::Result<Option<DBValue>> {
+		self.in_memory.get(col, key)
+	}
+
+	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>> {
+		self.in_memory.get_by_prefix(col, prefix)
+	}
+
+	fn write(&self, transaction: DBTransaction) -> io::Result<()> {
+		let _ = indexed_db::idb_commit_transaction(&*self.indexed_db, &transaction, self.columns);
+		self.in_memory.write(transaction)
+	}
+
+	// NOTE: clones the whole db
+	fn iter<'a>(&'a self, col: u32) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+		self.in_memory.iter(col)
+	}
+
+	// NOTE: clones the whole db
+	fn iter_with_prefix<'a>(
+		&'a self,
+		col: u32,
+		prefix: &'a [u8],
+	) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+		self.in_memory.iter_with_prefix(col, prefix)
+	}
+
+	// NOTE: not supported
+	fn restore(&self, _new_db: &str) -> std::io::Result<()> {
+		Err(io::Error::new(io::ErrorKind::Other, "Not supported yet"))
+	}
+}

--- a/libs/kvdb-web/tests/indexed_db.rs
+++ b/libs/kvdb-web/tests/indexed_db.rs
@@ -1,0 +1,94 @@
+// Copyright 2020 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! IndexedDB tests.
+
+use futures::future::TryFutureExt as _;
+
+use kvdb_shared_tests as st;
+use kvdb_web::{Database, KeyValueDB as _};
+
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+async fn open_db(col: u32, name: &str) -> Database {
+	Database::open(name.into(), col).unwrap_or_else(|err| panic!("{}", err)).await
+}
+
+#[wasm_bindgen_test]
+async fn get_fails_with_non_existing_column() {
+	let db = open_db(1, "get_fails_with_non_existing_column").await;
+	st::test_get_fails_with_non_existing_column(&db).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn put_and_get() {
+	let db = open_db(1, "put_and_get").await;
+	st::test_put_and_get(&db).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn delete_and_get() {
+	let db = open_db(1, "delete_and_get").await;
+	st::test_delete_and_get(&db).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn delete_prefix() {
+	let db = open_db(st::DELETE_PREFIX_NUM_COLUMNS, "delete_prefix").await;
+	st::test_delete_prefix(&db).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn iter() {
+	let db = open_db(1, "iter").await;
+	st::test_iter(&db).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn iter_with_prefix() {
+	let db = open_db(1, "iter_with_prefix").await;
+	st::test_iter_with_prefix(&db).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn complex() {
+	let db = open_db(1, "complex").await;
+	st::test_complex(&db).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn reopen_the_database_with_more_columns() {
+	let _ = console_log::init_with_level(log::Level::Trace);
+
+	let db = open_db(1, "reopen_the_database_with_more_columns").await;
+
+	// Write a value into the database
+	let mut batch = db.transaction();
+	batch.put(0, b"hello", b"world");
+	db.write(batch).unwrap();
+
+	assert_eq!(db.get(0, b"hello").unwrap().unwrap(), b"world");
+
+	// Check the database version
+	assert_eq!(db.version(), 1);
+
+	// Close the database
+	drop(db);
+
+	// Reopen it again with 3 columns
+	let db = open_db(3, "reopen_the_database_with_more_columns").await;
+
+	// The value should still be present
+	assert_eq!(db.get(0, b"hello").unwrap().unwrap(), b"world");
+	assert!(db.get(0, b"trash").unwrap().is_none());
+
+	// The version should be bumped
+	assert_eq!(db.version(), 2);
+}

--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs-wasm"
 description = "A higher level zkBob API for Wasm"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -37,7 +37,7 @@ libzeropool = { git = "https://github.com/zkBob/libzeropool", branch = "multicor
 getrandom = { version = "0.2.3", features = ["js"] }
 fawkes-crypto = { git = "https://github.com/zkBob/fawkes-crypto", branch = "multicore-wasm", version = "4.2.4", features = ["wasm", "multicore", "serde_support"] }
 bs58 = "0.4.0"
-kvdb-web = "0.9.0"
+kvdb-web = { version = "0.9.0", path = "../libs/kvdb-web"}
 kvdb = "0.9.0"
 kvdb-memorydb = "0.9.0"
 byteorder = "1.4.3"

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs"
 description = "A higher level zkBob API"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -12,7 +12,7 @@ libzeropool = { git = "https://github.com/zkBob/libzeropool", branch = "multicor
 getrandom = { version = "0.2.3" }
 bs58 = "0.4.0"
 kvdb = "0.9.0"
-kvdb-web = { version = "0.9.0", optional = true }
+kvdb-web = { version = "0.9.0", path = "../libs/kvdb-web", optional = true }
 borsh = "0.9.1"
 base64 = "0.13.0"
 byteorder = "1.4.3"


### PR DESCRIPTION
* Add Web Workers support in kvdb_web

* Revert "Add Web Workers support in kvdb_web"

This reverts commit f0e8c705710c1ca8d7ef1488c9858d587e6916ea.

* Vendor kvdb-web 0.9

(cherry picked from commit beb8c6818a8e56de023060938045a8adec7fb668)

* Fix dependencies

* Add Web Workers support in kvdb_web

Co-authored-by: Dmitry Vdovin <voidxnull@gmail.com>