### PR TITLE
Multithread/singlethread builds fixes

### DIFF
--- a/libzkbob-rs-wasm/scripts/build
+++ b/libzkbob-rs-wasm/scripts/build
@@ -2,6 +2,8 @@
 
 set -e
 
+RUSTUP_MT_TOOLCHAIN=nightly-2022-12-11
+RUSTUP_ST_TOOLCHAIN=stable-2022-11-03
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 
 if ! command -v jq &> /dev/null
@@ -20,11 +22,12 @@ function patch_package_json () {
 function build () {
   if [ "$3" = true ] ; then	
     RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
-      rustup run nightly \
+      rustup run $RUSTUP_MT_TOOLCHAIN \
       wasm-pack build --release --target web -d $1 \
       -- --features $2 -Z build-std=panic_abort,std	
-  else	
-    wasm-pack build --release --target web -d $1 -- --features $2	
+  else
+    rustup run $RUSTUP_ST_TOOLCHAIN \
+      wasm-pack build --release --target web -d $1 -- --features $2	
   fi
 
   # Optimize the binary, since wasm-pack refuses to see wasm-opt


### PR DESCRIPTION
1. Fix rustup toolchain versions for multicore and singlecore builds
2. Replace into_par_iter with helpers::vec_into_inter