### PR TITLE
Reduce number of runtime allocations

### DIFF
--- a/libzkbob-rs-wasm/scripts/build
+++ b/libzkbob-rs-wasm/scripts/build
@@ -2,6 +2,8 @@
 
 set -e
 
+RUSTUP_MT_TOOLCHAIN=nightly-2022-12-11
+RUSTUP_ST_TOOLCHAIN=stable-2022-11-03
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 
 if ! command -v jq &> /dev/null
@@ -20,11 +22,12 @@ function patch_package_json () {
 function build () {
   if [ "$3" = true ] ; then	
     RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
-      rustup run nightly \
+      rustup run $RUSTUP_MT_TOOLCHAIN \
       wasm-pack build --release --target web -d $1 \
       -- --features $2 -Z build-std=panic_abort,std	
-  else	
-    wasm-pack build --release --target web -d $1 -- --features $2	
+  else
+    rustup run $RUSTUP_ST_TOOLCHAIN \
+      wasm-pack build --release --target web -d $1 -- --features $2	
   fi
 
   # Optimize the binary, since wasm-pack refuses to see wasm-opt

--- a/libzkbob-rs-wasm/src/client/tx_parser.rs
+++ b/libzkbob-rs-wasm/src/client/tx_parser.rs
@@ -82,7 +82,7 @@ impl TxParser {
             parse_tx(index, &commitment, &memo, None, &eta, params)
         }).collect();
 
-        let mut parse_result = parse_results
+        let parse_result = parse_results
             .into_iter()
             .fold(Default::default(), |acc: ParseResult, parse_result| {
                 ParseResult {
@@ -95,8 +95,6 @@ impl TxParser {
                     }
                 }
         });
-
-        parse_result.decrypted_memos.sort_by(|a,b| a.index.cmp(&b.index));
 
         let parse_result = serde_wasm_bindgen::to_value(&parse_result)
             .unwrap()
@@ -120,7 +118,7 @@ pub fn parse_tx(
         .map(|bytes| Num::from_uint_reduced(NumRepr(Uint::from_little_endian(bytes))))
         .collect();
     
-    let pair = cipher::decrypt_out(*eta, &memo.clone(), params);
+    let pair = cipher::decrypt_out(*eta, &memo, params);
 
     match pair {
         Some((account, notes)) => {        
@@ -140,7 +138,7 @@ pub fn parse_tx(
                 decrypted_memos: vec![ DecMemo {
                     index,
                     acc: Some(account),
-                    in_notes: in_notes.clone().into_iter().map(|(index, note)| IndexedNote{index, note}).collect(), 
+                    in_notes: in_notes.iter().map(|(index, note)| IndexedNote{index: *index, note: *note}).collect(), 
                     out_notes: out_notes.into_iter().map(|(index, note)| IndexedNote{index, note}).collect(), 
                     tx_hash: match tx_hash {
                         Some(bytes) => Some(format!("0x{}", hex::encode(bytes))),
@@ -175,7 +173,7 @@ pub fn parse_tx(
                 ParseResult {
                     decrypted_memos: vec![ DecMemo{
                         index, 
-                        in_notes: in_notes.clone().into_iter().map(|(index, note)| IndexedNote{index, note}).collect(), 
+                        in_notes: in_notes.iter().map(|(index, note)| IndexedNote{index: *index, note: *note}).collect(), 
                         tx_hash: match tx_hash {
                             Some(bytes) => Some(format!("0x{}", hex::encode(bytes))),
                             None        => None,

--- a/libzkbob-rs-wasm/src/client/tx_parser.rs
+++ b/libzkbob-rs-wasm/src/client/tx_parser.rs
@@ -112,11 +112,10 @@ pub fn parse_tx(
     params: &PoolParams
 ) -> ParseResult {
     let num_hashes = (&memo[0..4]).read_u32::<LittleEndian>().unwrap();
-    let hashes: Vec<_> = (&memo[4..])
+    let hashes = (&memo[4..])
         .chunks(32)
         .take(num_hashes as usize)
-        .map(|bytes| Num::from_uint_reduced(NumRepr(Uint::from_little_endian(bytes))))
-        .collect();
+        .map(|bytes| Num::from_uint_reduced(NumRepr(Uint::from_little_endian(bytes))));
     
     let pair = cipher::decrypt_out(*eta, &memo, params);
 
@@ -147,7 +146,7 @@ pub fn parse_tx(
                     ..Default::default()
                 }],
                 state_update: StateUpdate {
-                    new_leafs: vec![(index, hashes)],
+                    new_leafs: vec![(index, hashes.collect())],
                     new_accounts: vec![(index, account)],
                     new_notes: vec![in_notes],
                     ..Default::default()
@@ -181,7 +180,7 @@ pub fn parse_tx(
                         ..Default::default()
                     }],
                     state_update: StateUpdate {
-                        new_leafs: vec![(index, hashes)],
+                        new_leafs: vec![(index, hashes.collect())],
                         new_notes: vec![in_notes],
                         ..Default::default()
                     }


### PR DESCRIPTION
In this PR, the following was done:
* Unnecessary clone()-s and collect()-s were removed
* Unnecessary sort in parse_tx was removed (it is unnecessary because rayon's parallel iterator ensures orderer)

These changes can improve performance on Mac M1 and slightly improve overall performance.