### PR TITLE
Add getRootAt binding

### DIFF
--- a/libzkbob-rs-node/index.d.ts
+++ b/libzkbob-rs-node/index.d.ts
@@ -29,6 +29,7 @@ declare class MerkleTree {
     getLeftSiblings(index: number): string[];
     getLastStableIndex(): number;
     setLastStableIndex(index: number): void;
+    getRootAt(index: number): string;
 }
 
 declare class TxStorage {

--- a/libzkbob-rs-node/index.js
+++ b/libzkbob-rs-node/index.js
@@ -77,6 +77,10 @@ class MerkleTree {
     setLastStableIndex(index) {
         zp.merkleSetLastStableIndex(this.inner, index)
     };
+
+    getRootAt(index) {
+        return zp.merkleGetRootAt(this.inner, index)
+    }
 }
 
 class TxStorage {

--- a/libzkbob-rs-node/src/lib.rs
+++ b/libzkbob-rs-node/src/lib.rs
@@ -67,6 +67,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("merkleGetLeftSiblings", merkle::merkle_get_left_siblings)?;
     cx.export_function("merkleGetLastStableIndex", merkle::merkle_get_last_stable_index)?;
     cx.export_function("merkleSetLastStableIndex", merkle::merkle_set_last_stable_index)?;
+    cx.export_function("merkleGetRootAt", merkle::merkle_get_root_at)?;
 
     cx.export_function("txStorageNew", storage::tx_storage_new)?;
     cx.export_function("txStorageAdd", storage::tx_storage_add)?;

--- a/libzkbob-rs-node/src/merkle.rs
+++ b/libzkbob-rs-node/src/merkle.rs
@@ -297,3 +297,17 @@ pub fn merkle_set_last_stable_index(mut cx: FunctionContext) -> JsResult<JsUndef
 
     Ok(cx.undefined())
 }
+
+pub fn merkle_get_root_at(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let tree = cx.argument::<BoxedMerkleTree>(0)?;
+
+    let index = {
+        let num = cx.argument::<JsNumber>(1)?;
+        num.value(&mut cx) as u64
+    };
+
+    let root = tree.read().unwrap().inner.get_root_at(index);
+    let result = neon_serde::to_value(&mut cx, &root).unwrap();
+
+    Ok(result)
+}

--- a/libzkbob-rs/src/merkle.rs
+++ b/libzkbob-rs/src/merkle.rs
@@ -439,7 +439,7 @@ impl<D: KeyValueDB, P: PoolParams> MerkleTree<D, P> {
 
     // Get root at specified index (without rollback)
     // This method can be used for tree integrity check
-    // index is a possition within Merkle tree level 0
+    // index is a position within Merkle tree level 0
     // and should point to the first transaction leaf
     //  (to be a multiple of constants::OUT + 1)
     pub fn get_root_at(&self, index: u64) -> Option<Hash<P::Fr>> {


### PR DESCRIPTION
Add neon binding for `getRootAt` method. It can be used instead of `RootSet` storage in relayer to simplify the worker's logic.