### PR TITLE
Feature/compliance

### DIFF
--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs-wasm"
 description = "A higher level zkBob API for Wasm"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -34,7 +34,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 
 libzkbob-rs = { path = "../libzkbob-rs" }
-libzeropool = { git = "https://github.com/zkBob/libzeropool", branch = "multicore-wasm", version = "0.5.6", default-features = false }
+libzeropool = { git = "https://github.com/zkBob/libzeropool", branch = "feature/compliance", version = "0.5.6", default-features = false }
 getrandom = { version = "0.2.3", features = ["js"] }
 fawkes-crypto = { git = "https://github.com/zkBob/fawkes-crypto", branch = "multicore-wasm", version = "4.2.4", features = ["wasm", "serde_support"] }
 bs58 = "0.4.0"

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -312,7 +312,6 @@ impl UserAccount {
 
     #[wasm_bindgen(js_name = "createTransferOptimistic")]
     pub fn create_tranfer_optimistic(&self, transfer: ITransferData, new_state: &JsValue) -> Result<Promise, JsValue> {
-        //let new_state: StateUpdate = new_state.into_serde().map_err(|err| js_err!(&err.to_string()))?;
         let new_state: StateUpdate = serde_wasm_bindgen::from_value(new_state.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
         Ok(self.construct_tx_data(transfer.to_native()?, Some(new_state)))
     }
@@ -324,7 +323,6 @@ impl UserAccount {
 
     #[wasm_bindgen(js_name = "createWithdrawalOptimistic")]
     pub fn create_withdraw_optimistic(&self, withdraw: IWithdrawData, new_state: &JsValue) -> Result<Promise, JsValue> {
-        //let new_state: StateUpdate = new_state.into_serde().map_err(|err| js_err!(&err.to_string()))?;
         let new_state: StateUpdate = serde_wasm_bindgen::from_value(new_state.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
         Ok(self.construct_tx_data(withdraw.to_native()?, Some(new_state)))
     }
@@ -407,10 +405,8 @@ impl UserAccount {
 
     #[wasm_bindgen(js_name = "updateState")]
     pub fn update_state(&mut self, state_update: &JsValue, siblings: Option<TreeNodes>) -> Result<(), JsValue> {
-        //let state_update: StateUpdate = state_update.into_serde().map_err(|err| js_err!(&err.to_string()))?;
         let state_update: StateUpdate = serde_wasm_bindgen::from_value(state_update.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
         let siblings: Option<Vec<Node<Fr>>> = match siblings {
-            //Some(val) => val.into_serde().map_err(|err| js_err!(&err.to_string()))?,
             Some(val) => serde_wasm_bindgen::from_value(val.unchecked_into()).map_err(|err| js_err!(&err.to_string()))?,
             None => None
         };

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -21,7 +21,7 @@ use libzeropool::{
     },
 };
 use libzkbob_rs::{
-    client::{TxType as NativeTxType, UserAccount as NativeUserAccount, StateFragment, TransactionInputs},
+    client::{TxType as NativeTxType, UserAccount as NativeUserAccount, StateFragment},
     merkle::{Hash, Node}
 };
 use serde::{Serialize};

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -499,7 +499,7 @@ impl UserAccount {
     #[wasm_bindgen(js_name = "getTxInputs")]
     /// Returns transaction inputs: account and notes
     pub fn get_tx_inputs(&self, index: u64) -> Result<TxInput, JsValue> {
-        if index & constants::OUTPLUSONELOG as u64 != 0 {
+        if index & constants::OUT as u64 != 0 {
             return Err(js_err!(&format!("Account index should be multiple of {}", constants::OUT + 1)));
         }
 

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -28,7 +28,7 @@ use serde::{Serialize};
 use wasm_bindgen::{prelude::*, JsCast };
 use wasm_bindgen_futures::future_to_promise;
 
-use crate::{ParseTxsColdStorageResult, TxInput};
+use crate::{ParseTxsColdStorageResult, TxInput, TxInputNodes, IndexedAccount};
 use crate::client::tx_parser::StateUpdate;
 
 use crate::database::Database;
@@ -487,8 +487,23 @@ impl UserAccount {
             .get_tx_input(index)
             .ok_or_else(|| js_err!("No account found at index {}", index))?;
             
+        let res = TxInputNodes {
+            account: IndexedAccount {
+                index: inputs.account.0,
+                account: inputs.account.1
+            },
+            notes:  inputs
+                    .notes.into_iter()
+                    .map(|note| {
+                        IndexedNote {
+                            index: note.0,
+                            note: note.1,
+                        }
+                    })
+                    .collect()
+        };
 
-        Ok(serde_wasm_bindgen::to_value(&inputs)
+        Ok(serde_wasm_bindgen::to_value(&res)
             .unwrap()
             .unchecked_into::<TxInput>())
     }

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -514,6 +514,7 @@ impl UserAccount {
                 index: inputs.account.0,
                 account: inputs.account.1
             },
+            intermediate_nullifier: inputs.intermediate_nullifier,
             notes:  inputs
                     .notes.into_iter()
                     .map(|note| {

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -88,7 +88,7 @@ impl UserAccount {
     }
 
     #[wasm_bindgen(js_name = "calculateNullifier")]
-    /// Generates a new private address.
+    /// Calculate nullifier from the account
     pub fn calculate_nullifier(&self, account: Account, index: u64) -> Result<JsHash, JsValue> {
         let in_account: NativeAccount<Fr> = serde_wasm_bindgen::from_value(account.into())?;
 

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::{cell::RefCell, convert::TryInto};
 
-use libzeropool::native::tx::nullifier;
+use libzkbob_rs::libzeropool::native::tx::nullifier;
 #[cfg(feature = "multicore")]
 use rayon::prelude::*;
 

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -312,7 +312,8 @@ impl UserAccount {
 
     #[wasm_bindgen(js_name = "createTransferOptimistic")]
     pub fn create_tranfer_optimistic(&self, transfer: ITransferData, new_state: &JsValue) -> Result<Promise, JsValue> {
-        let new_state: StateUpdate = new_state.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        //let new_state: StateUpdate = new_state.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        let new_state: StateUpdate = serde_wasm_bindgen::from_value(new_state.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
         Ok(self.construct_tx_data(transfer.to_native()?, Some(new_state)))
     }
 
@@ -323,7 +324,8 @@ impl UserAccount {
 
     #[wasm_bindgen(js_name = "createWithdrawalOptimistic")]
     pub fn create_withdraw_optimistic(&self, withdraw: IWithdrawData, new_state: &JsValue) -> Result<Promise, JsValue> {
-        let new_state: StateUpdate = new_state.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        //let new_state: StateUpdate = new_state.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        let new_state: StateUpdate = serde_wasm_bindgen::from_value(new_state.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
         Ok(self.construct_tx_data(withdraw.to_native()?, Some(new_state)))
     }
 
@@ -405,9 +407,11 @@ impl UserAccount {
 
     #[wasm_bindgen(js_name = "updateState")]
     pub fn update_state(&mut self, state_update: &JsValue, siblings: Option<TreeNodes>) -> Result<(), JsValue> {
-        let state_update: StateUpdate = state_update.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        //let state_update: StateUpdate = state_update.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        let state_update: StateUpdate = serde_wasm_bindgen::from_value(state_update.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
         let siblings: Option<Vec<Node<Fr>>> = match siblings {
-            Some(val) => val.into_serde().map_err(|err| js_err!(&err.to_string()))?,
+            //Some(val) => val.into_serde().map_err(|err| js_err!(&err.to_string()))?,
+            Some(val) => serde_wasm_bindgen::from_value(val.unchecked_into()).map_err(|err| js_err!(&err.to_string()))?,
             None => None
         };
         

--- a/libzkbob-rs-wasm/src/client/tx_parser.rs
+++ b/libzkbob-rs-wasm/src/client/tx_parser.rs
@@ -129,7 +129,6 @@ impl TxParser {
         let params = &self.params;
         let eta = Keys::derive(sk, params).eta;
 
-        //let txs: Vec<IndexedTx> = txs.into_serde().map_err(|err| js_err!(&err.to_string()))?;
         let txs: Vec<IndexedTx> = serde_wasm_bindgen::from_value(txs.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
 
         let (parse_results, parse_errors): (Vec<_>, Vec<_>) = vec_into_iter(txs)

--- a/libzkbob-rs-wasm/src/client/tx_parser.rs
+++ b/libzkbob-rs-wasm/src/client/tx_parser.rs
@@ -129,7 +129,8 @@ impl TxParser {
         let params = &self.params;
         let eta = Keys::derive(sk, params).eta;
 
-        let txs: Vec<IndexedTx> = txs.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        //let txs: Vec<IndexedTx> = txs.into_serde().map_err(|err| js_err!(&err.to_string()))?;
+        let txs: Vec<IndexedTx> = serde_wasm_bindgen::from_value(txs.to_owned()).map_err(|err| js_err!(&err.to_string()))?;
 
         let (parse_results, parse_errors): (Vec<_>, Vec<_>) = vec_into_iter(txs)
             .map(|tx| -> Result<ParseResult, ParseError> {

--- a/libzkbob-rs-wasm/src/client/tx_parser.rs
+++ b/libzkbob-rs-wasm/src/client/tx_parser.rs
@@ -24,7 +24,7 @@ use rayon::prelude::*;
 
 use crate::{PoolParams, Fr, IndexedNote, IndexedTx, Fs,
             ParseTxsResult, POOL_PARAMS, helpers::vec_into_iter,
-            TxMemoChunk, TxInput,
+            TxMemoChunk,
         };
 
 #[derive(Serialize, Deserialize, Clone, Default)]

--- a/libzkbob-rs-wasm/src/client/tx_parser.rs
+++ b/libzkbob-rs-wasm/src/client/tx_parser.rs
@@ -9,11 +9,23 @@ use libzkbob_rs::libzeropool::{
             decrypt_account_no_validate,
             decrypt_note_no_validate
         },
-        key
+        key::{
+            self,derive_key_p_d
+        }
     },
-    fawkes_crypto::ff_uint::{ Num, NumRepr, Uint }
+    fawkes_crypto::ff_uint::{ Num, NumRepr, Uint },
+    constants,
 };
-use libzkbob_rs::{merkle::Hash, keys::Keys};
+use libzkbob_rs::{
+    merkle::Hash,
+    keys::Keys,
+    utils::zero_account,
+    delegated_deposit::{
+        DELEGATED_DEPOSIT_FLAG,
+        MEMO_DELEGATED_DEPOSIT_SIZE,
+        MemoDelegatedDeposit
+    }
+};
 use wasm_bindgen::{prelude::*, JsCast};
 use serde::{Serialize, Deserialize};
 use std::iter::IntoIterator;

--- a/libzkbob-rs-wasm/src/client/tx_parser.rs
+++ b/libzkbob-rs-wasm/src/client/tx_parser.rs
@@ -6,8 +6,8 @@ use libzeropool::{
         cipher::{
             self,
             symcipher_decryption_keys,
-            decrypt_account,
-            decrypt_note
+            decrypt_account_no_validate,
+            decrypt_note_no_validate
         },
         key
     },
@@ -161,7 +161,7 @@ impl TxParser {
 
     #[wasm_bindgen(js_name = "symcipherDecryptAcc")]
     pub fn symcipher_decrypt_acc(&self, sym_key: &[u8], encrypted: &[u8] ) -> Result<Account, JsValue> {
-        let acc = decrypt_account(sym_key, encrypted, &self.params)
+        let acc = decrypt_account_no_validate(sym_key, encrypted, &self.params)
                                 .ok_or_else(|| js_err!("Unable to decrypt account"))?;
         
         Ok(serde_wasm_bindgen::to_value(&acc).unwrap().unchecked_into::<Account>())
@@ -169,7 +169,7 @@ impl TxParser {
 
     #[wasm_bindgen(js_name = "symcipherDecryptNote")]
     pub fn symcipher_decrypt_note(&self, sym_key: &[u8], encrypted: &[u8] ) -> Result<Note, JsValue> {
-        let note = decrypt_note(sym_key, encrypted, &self.params)
+        let note = decrypt_note_no_validate(sym_key, encrypted, &self.params)
                                 .ok_or_else(|| js_err!("Unable to decrypt note"))?;
         
         Ok(serde_wasm_bindgen::to_value(&note).unwrap().unchecked_into::<Note>())

--- a/libzkbob-rs-wasm/src/ts_types.rs
+++ b/libzkbob-rs-wasm/src/ts_types.rs
@@ -1,3 +1,4 @@
+use fawkes_crypto::ff_uint::Num;
 use libzeropool::native::{
     note::Note as NativeNote,
     account::Account as NativeAccount,
@@ -24,11 +25,11 @@ export interface Note {
 }
 
 export interface Account {
-    eta: string;
+    d: string;
+    p_d: string;
     i: string;
     b: string;
     e: string;
-    t: string;
 }
 
 export interface TransferPub {
@@ -174,6 +175,7 @@ export interface TxMemoChunk {
 
 export interface TxInput {
     account: { index: number, account: Account };
+    intermediateNullifier: string
     notes: { index: number, note: Note }[];
 }
 
@@ -308,6 +310,8 @@ pub struct IndexedNote {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TxInputNodes {
     pub account: IndexedAccount,
+    #[serde(rename = "intermediateNullifier")]
+    pub intermediate_nullifier: Num<Fr>,   // intermediate nullifier hash
     pub notes: Vec<IndexedNote>,
 }
 

--- a/libzkbob-rs-wasm/src/ts_types.rs
+++ b/libzkbob-rs-wasm/src/ts_types.rs
@@ -1,4 +1,7 @@
-use libzeropool::native::note::Note as NativeNote;
+use libzeropool::native::{
+    note::Note as NativeNote,
+    account::Account as NativeAccount,
+};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -291,9 +294,21 @@ extern "C" {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+pub struct IndexedAccount {
+    pub index: u64,
+    pub account: NativeAccount<Fr>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 pub struct IndexedNote {
     pub index: u64,
     pub note: NativeNote<Fr>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TxInputNodes {
+    pub account: IndexedAccount,
+    pub notes: Vec<IndexedNote>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/libzkbob-rs-wasm/src/ts_types.rs
+++ b/libzkbob-rs-wasm/src/ts_types.rs
@@ -169,6 +169,11 @@ export interface TxMemoChunk {
     key: Uint8Array;
 }
 
+export interface TxInput {
+    account: { index: number, account: Account };
+    notes: { index: number, note: Note }[];
+}
+
 "#;
 
 #[wasm_bindgen]
@@ -280,6 +285,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "TxMemoChunk")]
     pub type TxMemoChunk;
+
+    #[wasm_bindgen(typescript_type = "TxInput")]
+    pub type TxInput;
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/libzkbob-rs-wasm/src/ts_types.rs
+++ b/libzkbob-rs-wasm/src/ts_types.rs
@@ -163,6 +163,12 @@ export interface ParseTxsColdStorageResult {
     decryptedLeafsCnt: number;
 }
 
+export interface TxMemoChunk {
+    index: number;
+    encrypted: Uint8Array;
+    key: Uint8Array;
+}
+
 "#;
 
 #[wasm_bindgen]
@@ -271,6 +277,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "ParseTxsColdStorageResult")]
     pub type ParseTxsColdStorageResult;
+
+    #[wasm_bindgen(typescript_type = "TxMemoChunk")]
+    pub type TxMemoChunk;
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs"
 description = "A higher level zkBob API"
-version = "1.1.0"
+version = "1.3.0"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"
@@ -24,9 +24,9 @@ hex = { version = "0.4.3", features = ["serde"] }
 
 [dependencies.libzeropool]
 git = "https://github.com/zkbob/libzeropool-zkbob"
-branch = "feature/compliance"
+branch = "master"
 package = "libzeropool-zkbob"
-version = "1.1.0"
+version = "1.2.0"
 default-features = false
 features = ["in3out127"]
 

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -24,7 +24,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 
 [dependencies.libzeropool]
 git = "https://github.com/zkbob/libzeropool-zkbob"
-branch = "master"
+branch = "feature/compliance"
 package = "libzeropool-zkbob"
 version = "1.1.0"
 default-features = false

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-libzeropool = { git = "https://github.com/zkBob/libzeropool", branch = "multicore-wasm", version = "0.5.6", default-features = false, features = ["in3out127"] }
+libzeropool = { git = "https://github.com/zkBob/libzeropool", branch = "feature/compliance", version = "0.5.6", default-features = false, features = ["in3out127"] }
 getrandom = { version = "0.2.3" }
 bs58 = "0.4.0"
 kvdb = "0.9.0"

--- a/libzkbob-rs/src/address.rs
+++ b/libzkbob-rs/src/address.rs
@@ -2,7 +2,6 @@ use std::convert::{TryInto};
 
 use crate::pools::Pool;
 use crate::{utils::keccak256, pools::{GENERIC_ADDRESS_PREFIX, POOL_ID_BITS}};
-use libzeropool::fawkes_crypto::ff_uint::Uint;
 use libzeropool::{
     constants,
     fawkes_crypto::{

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -664,58 +664,6 @@ mod tests {
 
     #[test]
     fn test_user_account_is_own_address() {
-        let params = POOL_PARAMS.clone();
-        let mut rng = CustomRng;
-        let state = State::init_test(POOL_PARAMS.clone());
-        let mut user_account = UserAccount::new(Num::ZERO, state, POOL_PARAMS.clone());
-
-        let mut acc1 = Account::sample(&mut rng, &params);
-        acc1.i = BoundedNum::new(Num::from_str("100").unwrap());
-        let mut acc2 = Account::sample(&mut rng, &params);
-        acc2.i = BoundedNum::new(Num::from_str("259").unwrap());
-
-        let note0 = (50, Note::sample(&mut rng, &params));
-        let note1 = (257, Note::sample(&mut rng, &params));
-        let note2 = (258, Note::sample(&mut rng, &params));
-        let note3 = (259, Note::sample(&mut rng, &params));
-        let note4 = (300, Note::sample(&mut rng, &params));
-        let note5 = (666, Note::sample(&mut rng, &params));
-
-        user_account.state.add_account(128, acc1);
-        user_account.state.add_note(note0.0, note0.1);
-        user_account.state.add_note(note1.0, note1.1);
-        user_account.state.add_note(note2.0, note2.1);
-        user_account.state.add_note(note3.0, note3.1);
-        user_account.state.add_note(note4.0, note4.1);
-        user_account.state.add_note(note5.0, note5.1);
-        user_account.state.add_account(1024, acc2);
-
-        (0..10).into_iter().for_each(|idx| {
-            user_account.state.add_note(1024 + idx + 1, Note::sample(&mut rng, &params))
-        });
-
-        let inputs1 = user_account.get_tx_input(128).unwrap();
-        assert!(inputs1.account.1 == user_account.initial_account());
-        assert!(inputs1.notes.contains(&note0));
-        assert!(!inputs1.notes.contains(&note1));
-        assert!(!inputs1.notes.contains(&note2));
-        assert!(!inputs1.notes.contains(&note3));
-        assert!(!inputs1.notes.contains(&note4));
-        assert!(!inputs1.notes.contains(&note5));
-
-        let inputs2 = user_account.get_tx_input(1024).unwrap();
-        assert!(inputs2.account.1 == acc1);
-        assert!(!inputs2.notes.contains(&note0));
-        assert!(inputs2.notes.contains(&note1));
-        assert!(inputs2.notes.contains(&note2));
-        assert!(!inputs2.notes.contains(&note3));
-        assert!(!inputs2.notes.contains(&note4));
-        assert!(!inputs2.notes.contains(&note5));
-
-    }
-
-    #[test]
-    fn test_tx_inputs() {
         let acc_1 = UserAccount::new(
             Num::ZERO,
             State::init_test(POOL_PARAMS.clone()),
@@ -735,5 +683,56 @@ mod tests {
 
         assert!(!acc_1.is_own_address(&address_2));
         assert!(!acc_2.is_own_address(&address_1));
+    }
+
+    #[test]
+    fn test_tx_inputs() {
+        let params = POOL_PARAMS.clone();
+        let mut rng = CustomRng;
+        let state = State::init_test(POOL_PARAMS.clone());
+        let mut user_account = UserAccount::new(Num::ZERO, state, POOL_PARAMS.clone());
+
+        let mut acc0 = Account::sample(&mut rng, &params);
+        acc0.i = BoundedNum::new(Num::from_str("0").unwrap());
+        let mut acc1 = Account::sample(&mut rng, &params);
+        acc1.i = BoundedNum::new(Num::from_str("51").unwrap());
+        let mut acc2 = Account::sample(&mut rng, &params);
+        acc2.i = BoundedNum::new(Num::from_str("259").unwrap());
+
+        let note0 = (50, Note::sample(&mut rng, &params));
+        let note1 = (257, Note::sample(&mut rng, &params));
+        let note2 = (258, Note::sample(&mut rng, &params));
+        let note3 = (259, Note::sample(&mut rng, &params));
+        let note4 = (300, Note::sample(&mut rng, &params));
+        let note5 = (666, Note::sample(&mut rng, &params));
+
+        user_account.state.add_account(0, acc0);
+        user_account.state.add_account(128, acc1);
+        user_account.state.add_note(note0.0, note0.1);
+        user_account.state.add_note(note1.0, note1.1);
+        user_account.state.add_note(note2.0, note2.1);
+        user_account.state.add_note(note3.0, note3.1);
+        user_account.state.add_note(note4.0, note4.1);
+        user_account.state.add_note(note5.0, note5.1);
+        user_account.state.add_account(1024, acc2);
+
+        (0..10).into_iter().for_each(|idx| {
+            user_account.state.add_note(1024 + idx + 1, Note::sample(&mut rng, &params))
+        });
+
+        let inputs0 = user_account.get_tx_input(0).unwrap();
+        assert!(inputs0.account.1 == user_account.initial_account());
+        assert_eq!(inputs0.notes.len(), 0);
+
+        let inputs1 = user_account.get_tx_input(128).unwrap();
+        assert!(inputs1.account.1 == acc0);
+        assert_eq!(inputs1.notes.len(), 1);
+        assert!(inputs1.notes.contains(&note0));
+
+        let inputs2 = user_account.get_tx_input(1024).unwrap();
+        assert!(inputs2.account.1 == acc1);
+        assert_eq!(inputs2.notes.len(), 2);
+        assert!(inputs2.notes.contains(&note1));
+        assert!(inputs2.notes.contains(&note2));
     }
 }

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -73,11 +73,8 @@ pub struct TransactionData<Fr: PrimeField> {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TransactionInputs<Fr: PrimeField> {
-    #[serde(bound(serialize = "", deserialize = ""))]
     pub account: (u64, Account<Fr>),
-    #[serde(bound(serialize = "", deserialize = ""))]
     pub intermediate_nullifier: Num<Fr>,   // intermediate nullifier hash
-    #[serde(bound(serialize = "", deserialize = ""))]
     pub notes: Vec<(u64, Note<Fr>)>,
 }
 

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -752,7 +752,12 @@ mod tests {
         let params = POOL_PARAMS.clone();
         let mut rng = CustomRng;
         let state = State::init_test(POOL_PARAMS.clone());
-        let mut user_account = UserAccount::new(Num::ZERO, Num::ZERO, state, POOL_PARAMS.clone());
+        let mut user_account = UserAccount::new(
+            Num::ZERO,
+            Pool::OptimismBOB,
+            state,
+            POOL_PARAMS.clone()
+        );
 
         let mut acc0 = Account::sample(&mut rng, &params);
         acc0.i = BoundedNum::new(Num::from_str("0").unwrap());

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -700,7 +700,7 @@ mod tests {
         let params = POOL_PARAMS.clone();
         let mut rng = CustomRng;
         let state = State::init_test(POOL_PARAMS.clone());
-        let mut user_account = UserAccount::new(Num::ZERO, state, POOL_PARAMS.clone());
+        let mut user_account = UserAccount::new(Num::ZERO, Num::ZERO, state, POOL_PARAMS.clone());
 
         let mut acc0 = Account::sample(&mut rng, &params);
         acc0.i = BoundedNum::new(Num::from_str("0").unwrap());

--- a/libzkbob-rs/src/client/state.rs
+++ b/libzkbob-rs/src/client/state.rs
@@ -201,7 +201,7 @@ where
 
     pub fn get_notes_in_range(&self, range: Range<u64>) -> Vec<(u64, Note<P::Fr>)> {
         self.txs
-            .iter_slice(range.start..=(if range.end==0 { 0 } else { range.end-1 }))
+            .iter_slice(range.start..=range.end.saturating_sub(1))
             .filter_map(|(idx, tx)| match tx {
                 Transaction::Note(note) => Some((idx, note)),
                 _ => None,

--- a/libzkbob-rs/src/client/state.rs
+++ b/libzkbob-rs/src/client/state.rs
@@ -6,7 +6,7 @@ use kvdb_memorydb::InMemory as MemoryDatabase;
 use kvdb_web::Database as WebDatabase;
 use libzeropool::{
     constants,
-    fawkes_crypto::{ff_uint::{Num, Uint}, ff_uint::PrimeField, BorshDeserialize, BorshSerialize},
+    fawkes_crypto::{ff_uint::Num, ff_uint::PrimeField, BorshDeserialize, BorshSerialize},
     native::{
         account::Account, account::Account as NativeAccount, note::Note, note::Note as NativeNote,
         params::PoolParams,

--- a/libzkbob-rs/src/client/state.rs
+++ b/libzkbob-rs/src/client/state.rs
@@ -201,7 +201,7 @@ where
 
     pub fn get_notes_in_range(&self, range: Range<u64>) -> Vec<(u64, Note<P::Fr>)> {
         self.txs
-            .iter_slice(range.start..=(range.end-1))
+            .iter_slice(range.start..=(if range.end==0 { 0 } else { range.end-1 }))
             .filter_map(|(idx, tx)| match tx {
                 Transaction::Note(note) => Some((idx, note)),
                 _ => None,

--- a/libzkbob-rs/src/delegated_deposit.rs
+++ b/libzkbob-rs/src/delegated_deposit.rs
@@ -171,13 +171,7 @@ impl<Fr: PrimeField> DelegatedDepositData<Fr> {
 mod tests {
     use std::str::FromStr;
 
-    use libzeropool::{
-        fawkes_crypto::backend::bellman_groth16::{engines::Bn256, verifier::verify, Parameters},
-        POOL_PARAMS,
-    };
-
     use super::*;
-    use crate::proof::prove_delegated_deposit;
 
     #[test]
     fn test_delegated_deposit_data_create_full() {


### PR DESCRIPTION
These changes are required to generate detailed compliance report within the client library. Added following routines in the wasm library:
- `extract_decrypt_keys` to get symmetric cipher keys needed to decrypt output tx items (account and notes)
- `symcipher_decrypt_acc` \ `symcipher_decrypt_acc` to decrypt account and notes from the memoblock (needed to verify report correctness during development)
- `get_tx_inputs` to find transaction inputs for the transaction: account and notes and intermediate nullifier from the input account
- `calculate_nullifier` to getting nullifier from the account
- few helper routines and unit-test for retrieving tx inputs
