### PR TITLE
Feature/delegated deposits v2 upstream

### DIFF
--- a/libzkbob-rs-node/Cargo.toml
+++ b/libzkbob-rs-node/Cargo.toml
@@ -15,7 +15,7 @@ libzkbob-rs = { path = "../libzkbob-rs", features = ["native"] }
 fawkes-crypto = { git = "https://github.com/zkbob/fawkes-crypto", branch = "feature/delegated-deposits", features = ["multicore"] }
 neon = { version = "0.10.0", default-features = false, features = ["channel-api", "napi-6", "promise-api", "task-api"] }
 # FIXME: Using a random fork for now
-neon-serde = { git = "https://github.com/NZXTCorp/neon-serde.git", branch = "refactor/update-neon-0.10" }
+neon-serde = { package = "neon-serde3", version = "0.10" }
 serde = "1.0.136"
 hex = "0.4.3"
 

--- a/libzkbob-rs-node/index.d.ts
+++ b/libzkbob-rs-node/index.d.ts
@@ -174,6 +174,13 @@ interface FullDelegatedDeposit {
     expired: string | number;
 }
 
+interface MemoDelegatedDeposit {
+    id: string | number;
+    receiver_d: string | number;
+    receiver_p: string | number;
+    denominated_amount: string | number;
+}
+
 declare class DelegatedDepositsData {
     public: DelegatedDepositBatchPub;
     secret: DelegatedDepositBatchSec;
@@ -181,6 +188,11 @@ declare class DelegatedDepositsData {
     out_commitment_hash: string;
 
     static create(
-        deposits: FullDelegatedDeposit[],
+        deposits: MemoDelegatedDeposit[],
     ): Promise<DelegatedDepositsData>;
 }
+
+declare function delegatedDepositsToCommitment(
+    deposits: MemoDelegatedDeposit[],
+): string;
+

--- a/libzkbob-rs-node/index.d.ts
+++ b/libzkbob-rs-node/index.d.ts
@@ -89,20 +89,6 @@ export interface TreeSec {
     prev_leaf: string;
 }
 
-interface DelegatedDeposit {
-    d: string;
-    p_d: string;
-    b: string;
-}
-
-interface DelegatedDepositBatchPub {
-    keccak_sum: string;
-}
-
-interface DelegatedDepositBatchSec {
-    deposits: DelegatedDeposit[];
-}
-
 export interface MerkleProof {
     sibling: string[];
     path: boolean[];
@@ -179,6 +165,20 @@ interface MemoDelegatedDeposit {
     receiver_d: string | number;
     receiver_p: string | number;
     denominated_amount: string | number;
+}
+
+interface DelegatedDeposit {
+    d: string;
+    p_d: string;
+    b: string;
+}
+
+interface DelegatedDepositBatchPub {
+    keccak_sum: string;
+}
+
+interface DelegatedDepositBatchSec {
+    deposits: DelegatedDeposit[];
 }
 
 declare class DelegatedDepositsData {

--- a/libzkbob-rs-node/index.d.ts
+++ b/libzkbob-rs-node/index.d.ts
@@ -90,18 +90,17 @@ export interface TreeSec {
 }
 
 interface DelegatedDeposit {
-    d: string,
-    p_d: string,
-    b: string,
+    d: string;
+    p_d: string;
+    b: string;
 }
 
 interface DelegatedDepositBatchPub {
-    keccak_sum: string,
+    keccak_sum: string;
 }
 
 interface DelegatedDepositBatchSec {
-    out_commitment_hash: string,
-    deposits: DelegatedDeposit[],
+    deposits: DelegatedDeposit[];
 }
 
 export interface MerkleProof {
@@ -166,19 +165,20 @@ declare class TransactionData {
 }
 
 interface FullDelegatedDeposit {
-    id: string | number,
-    owner: string | number,
-    receiver_d: string | number,
-    receiver_p: string | number,
-    denominated_amount: string | number,
-    denominated_fee: string | number,
-    expired: string | number,
+    id: string | number;
+    owner: string | number;
+    receiver_d: string | number;
+    receiver_p: string | number;
+    denominated_amount: string | number;
+    denominated_fee: string | number;
+    expired: string | number;
 }
 
 declare class DelegatedDepositsData {
     public: DelegatedDepositBatchPub;
     secret: DelegatedDepositBatchSec;
     memo: Buffer;
+    out_commitment_hash: string;
 
     static create(
         deposits: FullDelegatedDeposit[],

--- a/libzkbob-rs-node/package.json
+++ b/libzkbob-rs-node/package.json
@@ -16,7 +16,6 @@
     "index.d.ts",
     "src",
     "Cargo.toml",
-    "Cargo.lock",
     "LICENSE_APACHE",
     "LICENSE_MIT",
     "README.md"

--- a/libzkbob-rs-node/package.json
+++ b/libzkbob-rs-node/package.json
@@ -11,9 +11,22 @@
     "install": "npm run build-release",
     "test": "cargo test"
   },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "src",
+    "Cargo.toml",
+    "Cargo.lock",
+    "LICENSE_APACHE",
+    "LICENSE_MIT",
+    "README.md"
+  ],
   "author": "Dmitry Vdovin <voidxnull@gmail.com>",
   "license": "MIT OR Apache-2.0",
   "dependencies": {
     "cargo-cp-artifact": "^0.1"
+  },
+  "devDependencies": {
+    "@types/node": "18.13.0"
   }
 }

--- a/libzkbob-rs-node/src/lib.rs
+++ b/libzkbob-rs-node/src/lib.rs
@@ -95,6 +95,11 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "createDelegatedDepositTxAsync",
         tx::create_delegated_deposit_tx_async,
     )?;
-    
+
+    cx.export_function(
+        "delegatedDepositsToCommitment",
+        tx::delegated_deposits_to_commitment,
+    )?;
+
     Ok(())
 }

--- a/libzkbob-rs-node/src/tx.rs
+++ b/libzkbob-rs-node/src/tx.rs
@@ -2,9 +2,10 @@ use std::str::FromStr;
 
 use libzkbob_rs::{
     client::TransactionData,
-    delegated_deposit::{DelegatedDepositData, FullDelegatedDeposit},
+    delegated_deposit::{DelegatedDepositData, MemoDelegatedDeposit},
     libzeropool::{
-        fawkes_crypto::{ff_uint::Num, native::poseidon::MerkleProof},
+        constants,
+        fawkes_crypto::{core::sizedvec::SizedVec, ff_uint::Num, native::poseidon::MerkleProof},
         native::{
             account::Account,
             boundednum::BoundedNum,
@@ -12,17 +13,22 @@ use libzkbob_rs::{
                 DelegatedDeposit, DelegatedDepositBatchPub, DelegatedDepositBatchSec,
             },
             note::Note,
-            tx::{TransferPub, TransferSec, Tx},
+            tx::{out_commitment_hash, TransferPub, TransferSec, Tx},
         },
         POOL_PARAMS,
     },
+    utils::{zero_account, zero_note},
 };
 use neon::prelude::*;
 
 use crate::Fr;
 
-trait JsExt {
+trait ToJs {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue>;
+}
+
+trait FromJs {
+    fn from_js<'a, C: Context<'a>>(cx: &mut C, value: Handle<'a, JsValue>) -> Self;
 }
 
 fn string_or_num_to_u64<'a, C: Context<'a>>(cx: &mut C, value: Handle<'a, JsValue>) -> u64 {
@@ -44,51 +50,38 @@ fn string_or_num_to_num<'a, C: Context<'a>>(cx: &mut C, value: Handle<'a, JsValu
     }
 }
 
-fn full_delegated_deposit_from_js<'a, C: Context<'a>>(
-    cx: &mut C,
-    obj: &JsObject,
-) -> FullDelegatedDeposit<Fr> {
-    let id_js = obj.get_value(cx, "id").unwrap();
-    let id = string_or_num_to_u64(cx, id_js);
+impl FromJs for MemoDelegatedDeposit<Fr> {
+    fn from_js<'a, C: Context<'a>>(cx: &mut C, value: Handle<'a, JsValue>) -> Self {
+        let obj = value.downcast::<JsObject, _>(cx).unwrap();
 
-    let owner_str = obj.get::<JsString, _, _>(cx, "owner").unwrap().value(cx);
+        let id_js = obj.get_value(cx, "id").unwrap();
+        let id = string_or_num_to_u64(cx, id_js);
 
-    let owner_slice = owner_str.strip_prefix("0x").unwrap_or(&owner_str);
-    let owner = hex::decode(owner_slice).unwrap();
+        let receiver_d_js = obj.get_value(cx, "receiver_d").unwrap();
+        let receiver_d = string_or_num_to_num(cx, receiver_d_js);
 
-    let receiver_d_js = obj.get_value(cx, "receiver_d").unwrap();
-    let receiver_d = string_or_num_to_num(cx, receiver_d_js);
+        let receiver_p = obj.get_value(cx, "receiver_p").unwrap();
+        let receiver_p = string_or_num_to_num(cx, receiver_p);
 
-    let receiver_p = obj.get_value(cx, "receiver_p").unwrap();
-    let receiver_p = string_or_num_to_num(cx, receiver_p);
+        let denominated_amount_js = obj.get_value(cx, "denominated_amount").unwrap();
+        let denominated_amount = string_or_num_to_u64(cx, denominated_amount_js);
 
-    let denominated_amount_js = obj.get_value(cx, "denominated_amount").unwrap();
-    let denominated_amount = string_or_num_to_u64(cx, denominated_amount_js);
-
-    let denominated_fee_js = obj.get_value(cx, "denominated_fee").unwrap();
-    let denominated_fee = string_or_num_to_u64(cx, denominated_fee_js);
-
-    let expired_js = obj.get_value(cx, "expired").unwrap();
-    let expired = string_or_num_to_u64(cx, expired_js);
-
-    FullDelegatedDeposit {
-        id,
-        owner,
-        receiver_d: BoundedNum::new(receiver_d),
-        receiver_p,
-        denominated_amount,
-        denominated_fee,
-        expired,
+        MemoDelegatedDeposit {
+            id,
+            receiver_d: BoundedNum::new(receiver_d),
+            receiver_p,
+            denominated_amount,
+        }
     }
 }
 
-impl JsExt for bool {
+impl ToJs for bool {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         Ok(cx.boolean(*self).upcast())
     }
 }
 
-impl<T: JsExt> JsExt for &[T] {
+impl<T: ToJs> ToJs for &[T] {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let arr = JsArray::new(cx, self.len() as u32);
         for (i, item) in self.iter().enumerate() {
@@ -100,7 +93,7 @@ impl<T: JsExt> JsExt for &[T] {
     }
 }
 
-impl JsExt for DelegatedDepositData<Fr> {
+impl ToJs for DelegatedDepositData<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -117,7 +110,7 @@ impl JsExt for DelegatedDepositData<Fr> {
     }
 }
 
-impl JsExt for DelegatedDepositBatchPub<Fr> {
+impl ToJs for DelegatedDepositBatchPub<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -128,7 +121,7 @@ impl JsExt for DelegatedDepositBatchPub<Fr> {
     }
 }
 
-impl JsExt for DelegatedDepositBatchSec<Fr> {
+impl ToJs for DelegatedDepositBatchSec<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -139,7 +132,7 @@ impl JsExt for DelegatedDepositBatchSec<Fr> {
     }
 }
 
-impl JsExt for DelegatedDeposit<Fr> {
+impl ToJs for DelegatedDeposit<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -154,7 +147,7 @@ impl JsExt for DelegatedDeposit<Fr> {
     }
 }
 
-impl JsExt for TransactionData<Fr> {
+impl ToJs for TransactionData<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -180,7 +173,7 @@ impl JsExt for TransactionData<Fr> {
     }
 }
 
-impl JsExt for TransferPub<Fr> {
+impl ToJs for TransferPub<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -203,7 +196,7 @@ impl JsExt for TransferPub<Fr> {
     }
 }
 
-impl JsExt for TransferSec<Fr> {
+impl ToJs for TransferSec<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -228,7 +221,7 @@ impl JsExt for TransferSec<Fr> {
     }
 }
 
-impl<const L: usize> JsExt for MerkleProof<Fr, L> {
+impl<const L: usize> ToJs for MerkleProof<Fr, L> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -246,7 +239,7 @@ impl<const L: usize> JsExt for MerkleProof<Fr, L> {
     }
 }
 
-impl JsExt for Tx<Fr> {
+impl ToJs for Tx<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -270,7 +263,7 @@ impl JsExt for Tx<Fr> {
     }
 }
 
-impl JsExt for Account<Fr> {
+impl ToJs for Account<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -289,7 +282,7 @@ impl JsExt for Account<Fr> {
     }
 }
 
-impl JsExt for Note<Fr> {
+impl ToJs for Note<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
 
@@ -306,7 +299,7 @@ impl JsExt for Note<Fr> {
     }
 }
 
-impl JsExt for Num<Fr> {
+impl ToJs for Num<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let num = self.to_string();
         let num = cx.string(num);
@@ -319,10 +312,7 @@ pub fn create_delegated_deposit_tx_async(mut cx: FunctionContext) -> JsResult<Js
     let deposits_js = cx.argument::<JsArray>(0)?.to_vec(&mut cx)?;
     let deposits: Vec<_> = deposits_js
         .into_iter()
-        .map(|obj| {
-            let obj = obj.downcast_or_throw::<JsObject, _>(&mut cx).unwrap();
-            full_delegated_deposit_from_js(&mut cx, &obj)
-        })
+        .map(|obj| MemoDelegatedDeposit::from_js(&mut cx, obj))
         .collect();
 
     let promise = cx
@@ -336,4 +326,28 @@ pub fn create_delegated_deposit_tx_async(mut cx: FunctionContext) -> JsResult<Js
         });
 
     Ok(promise)
+}
+
+pub fn delegated_deposits_to_commitment(mut cx: FunctionContext) -> JsResult<JsString> {
+    let deposits_js = cx.argument::<JsArray>(0)?.to_vec(&mut cx)?;
+    let deposits: Vec<_> = deposits_js
+        .into_iter()
+        .map(|obj| MemoDelegatedDeposit::from_js(&mut cx, obj))
+        .collect();
+
+    let note_hashes = deposits
+        .into_iter()
+        .map(|d| d.to_delegated_deposit().to_note().hash(&*POOL_PARAMS));
+
+    let out_hashes: SizedVec<Num<Fr>, { constants::OUT + 1 }> =
+        std::iter::once(zero_account().hash(&*POOL_PARAMS))
+            .chain(note_hashes)
+            .chain(std::iter::repeat(zero_note().hash(&*POOL_PARAMS)))
+            .take(constants::OUT + 1)
+            .collect();
+
+    let out_commitment_hash = out_commitment_hash(out_hashes.as_slice(), &*POOL_PARAMS);
+    let res = out_commitment_hash.to_string();
+
+    Ok(cx.string(res))
 }

--- a/libzkbob-rs-node/src/tx.rs
+++ b/libzkbob-rs-node/src/tx.rs
@@ -106,6 +106,9 @@ impl ToJs for DelegatedDepositData<Fr> {
         let memo = JsBuffer::external(cx, self.memo.clone());
         obj.set(cx, "memo", memo)?;
 
+        let out_commitment_hash = cx.string(self.out_commitment_hash.to_string());
+        obj.set(cx, "out_commitment_hash", out_commitment_hash)?;
+
         Ok(obj.upcast())
     }
 }

--- a/libzkbob-rs-node/src/tx.rs
+++ b/libzkbob-rs-node/src/tx.rs
@@ -21,7 +21,6 @@ use neon::prelude::*;
 
 use crate::Fr;
 
-// TODO: How is there no similar trait in neon? Create a PR?
 trait JsExt {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue>;
 }
@@ -132,9 +131,6 @@ impl JsExt for DelegatedDepositBatchPub<Fr> {
 impl JsExt for DelegatedDepositBatchSec<Fr> {
     fn to_js<'a, C: Context<'a>>(&self, cx: &mut C) -> JsResult<'a, JsValue> {
         let obj = cx.empty_object();
-
-        let out_commitment_hash = cx.string(self.out_commitment_hash.to_string());
-        obj.set(cx, "out_commitment_hash", out_commitment_hash)?;
 
         let deposits = self.deposits.as_slice().to_js(cx)?;
         obj.set(cx, "deposits", deposits)?;

--- a/libzkbob-rs-node/yarn.lock
+++ b/libzkbob-rs-node/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/node@18.13.0":
+  version "18.13.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
+  integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
+
 cargo-cp-artifact@^0.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/cargo-cp-artifact/-/cargo-cp-artifact-0.1.7.tgz#1181b9d6e71f00f17c068c05e3cd1b0864783341"

--- a/libzkbob-rs/src/delegated_deposit.rs
+++ b/libzkbob-rs/src/delegated_deposit.rs
@@ -102,6 +102,7 @@ pub struct DelegatedDepositData<Fr: PrimeField> {
     pub public: DelegatedDepositBatchPub<Fr>,
     pub secret: DelegatedDepositBatchSec<Fr>,
     pub memo: Vec<u8>,
+    pub out_commitment_hash: Num<Fr>,
 }
 
 impl<Fr: PrimeField> DelegatedDepositData<Fr> {
@@ -165,7 +166,6 @@ impl<Fr: PrimeField> DelegatedDepositData<Fr> {
 
         let public = DelegatedDepositBatchPub { keccak_sum };
         let secret = DelegatedDepositBatchSec::<P::Fr> {
-            out_commitment_hash,
             deposits: deposits
                 .iter()
                 .map(FullDelegatedDeposit::to_delegated_deposit)
@@ -194,6 +194,7 @@ impl<Fr: PrimeField> DelegatedDepositData<Fr> {
             public,
             secret,
             memo: memo_data,
+            out_commitment_hash,
         })
     }
 }

--- a/libzkbob-rs/src/delegated_deposit.rs
+++ b/libzkbob-rs/src/delegated_deposit.rs
@@ -170,7 +170,7 @@ impl<Fr: PrimeField> DelegatedDepositData<Fr> {
         };
 
         let memo_data = {
-            let memo_size = 8 + 256 + 4 + 32 + 94 * deposits.len();
+            let memo_size = 4 + 58 * deposits.len();
             let mut data = Vec::with_capacity(memo_size);
             data.extend_from_slice(&DELEGATED_DEPOSIT_MAGIC);
 


### PR DESCRIPTION
- _Update libzeropool_ **skipped (already done)**
- _Spawn regular threads for async nodejs tasks instead of rayon_ **skipped (we already have similar fix: https://github.com/zkBob/libzkbob-rs/pull/48/commits/f78be268a6e0692b52763e5c7ca3a08dd0ed9f4b)**
- Clean up delegated deposits code
- Implement full test for delegated deposit creation/proofs/verification
- _Fix kvdb-web tests_  **skipped (we don't have such problem)**
- Fix preallocated vec size for the delegated deposit memo
- Fix keccak256 calculation in delegated deposits
- Update to latest libzeropool
- Improve test_delegated_deposit_data_create_full
- Add delegatedDepositsToCommitment to nodejs, simplify DD intefaces
- Fix package.json
- Update neon-serde, some small fixes
- Fix