### PR TITLE
Add ability to preparse gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,9 @@ default-members = [
     "libzkbob-rs-node",
     "libs/kvdb-web",
 ]
+
+[patch.crates-io]
+fawkes-crypto-zkbob = { git = "https://github.com/zkbob//fawkes-crypto", branch = "feature/preparse_gates" }
+
+[patch."https://github.com/zkbob/fawkes-crypto"]
+fawkes-crypto-zkbob = { git = "https://github.com/zkbob//fawkes-crypto", branch = "feature/preparse_gates" }

--- a/libzkbob-rs-node/Cargo.toml
+++ b/libzkbob-rs-node/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["index.node"]
 crate-type = ["cdylib"]
 
 [dependencies]
-libzkbob-rs = { version = "1.0.0", features = ["native"] }
+libzkbob-rs = { path = "../libzkbob-rs", features = ["native"] }
 #libzkbob-rs = { path = "../libzkbob-rs", features = ["native"] }
 neon = { version = "0.10.0", default-features = false, features = ["channel-api", "napi-6", "promise-api", "task-api"] }
 # FIXME: Using a random fork for now

--- a/libzkbob-rs-node/index.d.ts
+++ b/libzkbob-rs-node/index.d.ts
@@ -109,8 +109,8 @@ export interface VK {
 }
 
 declare class Params {
-    static fromBinary(data: Buffer): Params;
-    static fromFile(path: string): Params;
+    static fromBinary(data: Buffer, precompute: boolean): Params;
+    static fromFile(path: string, precompute: boolean): Params;
 }
 
 declare class Proof {

--- a/libzkbob-rs-node/src/params.rs
+++ b/libzkbob-rs-node/src/params.rs
@@ -1,14 +1,16 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use fawkes_crypto::backend::bellman_groth16::PrecomputedData;
 use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::Parameters;
 use neon::{prelude::*, types::buffer::TypedArray};
 
-use crate::Engine;
+use crate::{Engine, Fr};
 
 pub type BoxedParams = JsBox<Arc<Params>>;
 pub struct Params {
     pub inner: Parameters<Engine>,
+    pub precomputed: Option<PrecomputedData<Fr>>,
 }
 
 pub fn from_binary(mut cx: FunctionContext) -> JsResult<BoxedParams> {
@@ -16,8 +18,9 @@ pub fn from_binary(mut cx: FunctionContext) -> JsResult<BoxedParams> {
 
     let mut data = input.as_slice(&cx);
     let inner = Parameters::read(&mut data, true, true).unwrap();
-
-    Ok(cx.boxed(Arc::new(Params { inner })))
+    let precompute = cx.argument::<JsBoolean>(1)?.value(&mut cx);
+    let precomputed = precompute.then(|| inner.precompute());
+    Ok(cx.boxed(Arc::new(Params { inner, precomputed })))
 }
 
 pub fn from_file(mut cx: FunctionContext) -> JsResult<BoxedParams> {
@@ -28,8 +31,9 @@ pub fn from_file(mut cx: FunctionContext) -> JsResult<BoxedParams> {
 
     let data = std::fs::read(path).unwrap();
     let inner = Parameters::read(&mut data.as_slice(), true, true).unwrap();
-
-    Ok(cx.boxed(Arc::new(Params { inner })))
+    let precompute = cx.argument::<JsBoolean>(1)?.value(&mut cx);
+    let precomputed = precompute.then(|| inner.precompute());
+    Ok(cx.boxed(Arc::new(Params { inner, precomputed })))
 }
 
 impl Finalize for Params {}

--- a/libzkbob-rs-node/src/proof.rs
+++ b/libzkbob-rs-node/src/proof.rs
@@ -5,8 +5,12 @@ use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::verifier:
 use libzkbob_rs::libzeropool::fawkes_crypto::ff_uint::Num;
 use libzkbob_rs::libzeropool::POOL_PARAMS;
 use libzkbob_rs::proof::{
-    prove_delegated_deposit as prove_delegated_deposit_native, prove_tree as prove_tree_native,
+    prove_delegated_deposit as prove_delegated_deposit_native,
+    prove_delegated_deposit_precomputed as prove_delegated_deposit_native_precomputed, 
+    prove_tree as prove_tree_native,
+    prove_tree_precomputed as prove_tree_native_precomputed,
     prove_tx as prove_tx_native,
+    prove_tx_precomputed as prove_tx_native_precomputed,
 };
 use neon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -31,7 +35,21 @@ pub fn prove_tx_async(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
     let promise = cx
         .task(move || {
-            let (inputs, proof) = prove_tx_native(&params.inner, &*POOL_PARAMS, tr_pub, tr_sec);
+            let (inputs, proof) = match &params.precomputed {
+                Some(precomputed) => prove_tx_native_precomputed(
+                    &params.inner, 
+                    &*POOL_PARAMS, 
+                    tr_pub, 
+                    tr_sec, 
+                    &precomputed
+                ),
+                None => prove_tx_native(
+                    &params.inner, 
+                    &*POOL_PARAMS, 
+                    tr_pub, 
+                    tr_sec,
+                ),
+            };
             SnarkProof { inputs, proof }
         })
         .promise(move |mut cx, proof| {
@@ -50,7 +68,21 @@ pub fn prove_tree_async(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
     let promise = cx
         .task(move || {
-            let (inputs, proof) = prove_tree_native(&params.inner, &*POOL_PARAMS, tr_pub, tr_sec);
+            let (inputs, proof) = match &params.precomputed {
+                Some(precomputed) => prove_tree_native_precomputed(
+                    &params.inner, 
+                    &*POOL_PARAMS, 
+                    tr_pub, 
+                    tr_sec, 
+                    precomputed
+                ),
+                None => prove_tree_native(
+                    &params.inner, 
+                    &*POOL_PARAMS, 
+                    tr_pub, 
+                    tr_sec,
+                ),
+            };
             SnarkProof { inputs, proof }
         })
         .promise(move |mut cx, proof| {
@@ -69,8 +101,21 @@ pub fn prove_delegated_deposit_async(mut cx: FunctionContext) -> JsResult<JsProm
 
     let promise = cx
         .task(move || {
-            let (inputs, proof) =
-                prove_delegated_deposit_native(&params.inner, &*POOL_PARAMS, d_pub, d_sec);
+            let (inputs, proof) = match &params.precomputed {
+                Some(precomputed) => prove_delegated_deposit_native_precomputed(
+                    &params.inner, 
+                    &*POOL_PARAMS, 
+                    d_pub, 
+                    d_sec, 
+                    precomputed
+                ),
+                None => prove_delegated_deposit_native(
+                    &params.inner, 
+                    &*POOL_PARAMS, 
+                    d_pub, 
+                    d_sec,
+                ),
+            };
             SnarkProof { inputs, proof }
         })
         .promise(move |mut cx, proof| {
@@ -88,7 +133,21 @@ pub fn prove_tx(mut cx: FunctionContext) -> JsResult<JsValue> {
     let tr_pub = neon_serde::from_value(&mut cx, tr_pub_js).unwrap();
     let tr_sec = neon_serde::from_value(&mut cx, tr_sec_js).unwrap();
 
-    let pair = prove_tx_native(&params.inner, &*POOL_PARAMS, tr_pub, tr_sec);
+    let pair = match &params.precomputed {
+        Some(precomputed) => prove_tx_native_precomputed(
+            &params.inner, 
+            &*POOL_PARAMS, 
+            tr_pub, 
+            tr_sec, 
+            &precomputed
+        ),
+        None => prove_tx_native(
+            &params.inner, 
+            &*POOL_PARAMS, 
+            tr_pub, 
+            tr_sec,
+        ),
+    };
 
     let proof = SnarkProof {
         inputs: pair.0,
@@ -108,7 +167,21 @@ pub fn prove_tree(mut cx: FunctionContext) -> JsResult<JsValue> {
     let tr_pub = neon_serde::from_value(&mut cx, tr_pub_js).unwrap();
     let tr_sec = neon_serde::from_value(&mut cx, tr_sec_js).unwrap();
 
-    let pair = prove_tree_native(&params.inner, &*POOL_PARAMS, tr_pub, tr_sec);
+    let pair = match &params.precomputed {
+        Some(precomputed) => prove_tree_native_precomputed(
+            &params.inner, 
+            &*POOL_PARAMS, 
+            tr_pub, 
+            tr_sec, 
+            precomputed
+        ),
+        None => prove_tree_native(
+            &params.inner, 
+            &*POOL_PARAMS, 
+            tr_pub, 
+            tr_sec,
+        ),
+    };
 
     let proof = SnarkProof {
         inputs: pair.0,
@@ -128,8 +201,21 @@ pub fn prove_delegated_deposit(mut cx: FunctionContext) -> JsResult<JsValue> {
     let d_pub = neon_serde::from_value(&mut cx, d_pub_js).unwrap();
     let d_sec = neon_serde::from_value(&mut cx, d_sec_js).unwrap();
 
-    let (inputs, proof) =
-        prove_delegated_deposit_native(&params.inner, &*POOL_PARAMS, d_pub, d_sec);
+    let (inputs, proof) = match &params.precomputed {
+        Some(precomputed) => prove_delegated_deposit_native_precomputed(
+            &params.inner, 
+            &*POOL_PARAMS, 
+            d_pub, 
+            d_sec, 
+            precomputed
+        ),
+        None => prove_delegated_deposit_native(
+            &params.inner, 
+            &*POOL_PARAMS, 
+            d_pub, 
+            d_sec,
+        ),
+    };
 
     let proof = SnarkProof { inputs, proof };
 

--- a/libzkbob-rs-node/src/proof.rs
+++ b/libzkbob-rs-node/src/proof.rs
@@ -6,11 +6,8 @@ use libzkbob_rs::libzeropool::fawkes_crypto::ff_uint::Num;
 use libzkbob_rs::libzeropool::POOL_PARAMS;
 use libzkbob_rs::proof::{
     prove_delegated_deposit as prove_delegated_deposit_native,
-    prove_delegated_deposit_precomputed as prove_delegated_deposit_native_precomputed, 
     prove_tree as prove_tree_native,
-    prove_tree_precomputed as prove_tree_native_precomputed,
     prove_tx as prove_tx_native,
-    prove_tx_precomputed as prove_tx_native_precomputed,
 };
 use neon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -35,21 +32,13 @@ pub fn prove_tx_async(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
     let promise = cx
         .task(move || {
-            let (inputs, proof) = match &params.precomputed {
-                Some(precomputed) => prove_tx_native_precomputed(
-                    &params.inner, 
-                    &*POOL_PARAMS, 
-                    tr_pub, 
-                    tr_sec, 
-                    &precomputed
-                ),
-                None => prove_tx_native(
-                    &params.inner, 
-                    &*POOL_PARAMS, 
-                    tr_pub, 
-                    tr_sec,
-                ),
-            };
+            let (inputs, proof) = prove_tx_native(
+                &params.inner, 
+                &*POOL_PARAMS, 
+                tr_pub, 
+                tr_sec,
+                &params.precomputed,
+            );
             SnarkProof { inputs, proof }
         })
         .promise(move |mut cx, proof| {
@@ -68,21 +57,13 @@ pub fn prove_tree_async(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
     let promise = cx
         .task(move || {
-            let (inputs, proof) = match &params.precomputed {
-                Some(precomputed) => prove_tree_native_precomputed(
-                    &params.inner, 
-                    &*POOL_PARAMS, 
-                    tr_pub, 
-                    tr_sec, 
-                    precomputed
-                ),
-                None => prove_tree_native(
-                    &params.inner, 
-                    &*POOL_PARAMS, 
-                    tr_pub, 
-                    tr_sec,
-                ),
-            };
+            let (inputs, proof) = prove_tree_native(
+                &params.inner, 
+                &*POOL_PARAMS, 
+                tr_pub, 
+                tr_sec, 
+                &params.precomputed,
+            );
             SnarkProof { inputs, proof }
         })
         .promise(move |mut cx, proof| {
@@ -101,21 +82,13 @@ pub fn prove_delegated_deposit_async(mut cx: FunctionContext) -> JsResult<JsProm
 
     let promise = cx
         .task(move || {
-            let (inputs, proof) = match &params.precomputed {
-                Some(precomputed) => prove_delegated_deposit_native_precomputed(
-                    &params.inner, 
-                    &*POOL_PARAMS, 
-                    d_pub, 
-                    d_sec, 
-                    precomputed
-                ),
-                None => prove_delegated_deposit_native(
-                    &params.inner, 
-                    &*POOL_PARAMS, 
-                    d_pub, 
-                    d_sec,
-                ),
-            };
+            let (inputs, proof) = prove_delegated_deposit_native(
+                &params.inner, 
+                &*POOL_PARAMS, 
+                d_pub, 
+                d_sec, 
+                &params.precomputed,
+            );
             SnarkProof { inputs, proof }
         })
         .promise(move |mut cx, proof| {
@@ -133,21 +106,13 @@ pub fn prove_tx(mut cx: FunctionContext) -> JsResult<JsValue> {
     let tr_pub = neon_serde::from_value(&mut cx, tr_pub_js).unwrap();
     let tr_sec = neon_serde::from_value(&mut cx, tr_sec_js).unwrap();
 
-    let pair = match &params.precomputed {
-        Some(precomputed) => prove_tx_native_precomputed(
-            &params.inner, 
-            &*POOL_PARAMS, 
-            tr_pub, 
-            tr_sec, 
-            &precomputed
-        ),
-        None => prove_tx_native(
-            &params.inner, 
-            &*POOL_PARAMS, 
-            tr_pub, 
-            tr_sec,
-        ),
-    };
+    let pair = prove_tx_native(
+        &params.inner, 
+        &*POOL_PARAMS, 
+        tr_pub, 
+        tr_sec,
+        &params.precomputed,
+    );
 
     let proof = SnarkProof {
         inputs: pair.0,
@@ -167,21 +132,13 @@ pub fn prove_tree(mut cx: FunctionContext) -> JsResult<JsValue> {
     let tr_pub = neon_serde::from_value(&mut cx, tr_pub_js).unwrap();
     let tr_sec = neon_serde::from_value(&mut cx, tr_sec_js).unwrap();
 
-    let pair = match &params.precomputed {
-        Some(precomputed) => prove_tree_native_precomputed(
-            &params.inner, 
-            &*POOL_PARAMS, 
-            tr_pub, 
-            tr_sec, 
-            precomputed
-        ),
-        None => prove_tree_native(
-            &params.inner, 
-            &*POOL_PARAMS, 
-            tr_pub, 
-            tr_sec,
-        ),
-    };
+    let pair = prove_tree_native(
+        &params.inner, 
+        &*POOL_PARAMS, 
+        tr_pub, 
+        tr_sec, 
+        &params.precomputed,
+    );
 
     let proof = SnarkProof {
         inputs: pair.0,
@@ -201,21 +158,13 @@ pub fn prove_delegated_deposit(mut cx: FunctionContext) -> JsResult<JsValue> {
     let d_pub = neon_serde::from_value(&mut cx, d_pub_js).unwrap();
     let d_sec = neon_serde::from_value(&mut cx, d_sec_js).unwrap();
 
-    let (inputs, proof) = match &params.precomputed {
-        Some(precomputed) => prove_delegated_deposit_native_precomputed(
-            &params.inner, 
-            &*POOL_PARAMS, 
-            d_pub, 
-            d_sec, 
-            precomputed
-        ),
-        None => prove_delegated_deposit_native(
-            &params.inner, 
-            &*POOL_PARAMS, 
-            d_pub, 
-            d_sec,
-        ),
-    };
+    let (inputs, proof) = prove_delegated_deposit_native(
+        &params.inner, 
+        &*POOL_PARAMS, 
+        d_pub, 
+        d_sec, 
+        &params.precomputed,
+    );
 
     let proof = SnarkProof { inputs, proof };
 

--- a/libzkbob-rs-wasm/src/params.rs
+++ b/libzkbob-rs-wasm/src/params.rs
@@ -27,8 +27,8 @@ impl From<Params> for Parameters<Engine> {
 #[wasm_bindgen]
 impl Params {
     #[wasm_bindgen(js_name = "fromBinary")]
-    pub fn from_binary(input: &[u8], precompute: bool) -> Result<Params, JsValue> {
-        Self::from_binary_ext(input, true, true, precompute)
+    pub fn from_binary(input: &[u8]) -> Result<Params, JsValue> {
+        Self::from_binary_ext(input, true, true, false)
     }
 
     #[wasm_bindgen(js_name = "fromBinaryExtended")]

--- a/libzkbob-rs-wasm/src/params.rs
+++ b/libzkbob-rs-wasm/src/params.rs
@@ -1,17 +1,20 @@
+use fawkes_crypto::backend::bellman_groth16::PrecomputedData;
 use libzkbob_rs::libzeropool::fawkes_crypto::backend::bellman_groth16::Parameters;
 use wasm_bindgen::prelude::*;
 
-use crate::Engine;
+use crate::{Engine, Fr};
 
 #[wasm_bindgen]
 pub struct Params {
     #[wasm_bindgen(skip)]
     pub inner: Parameters<Engine>,
+    #[wasm_bindgen(skip)]
+    pub precomputed: Option<PrecomputedData<Fr>>
 }
 
 impl From<Parameters<Engine>> for Params {
     fn from(params: Parameters<Engine>) -> Self {
-        Params { inner: params }
+        Params { inner: params, precomputed: None }
     }
 }
 
@@ -24,15 +27,30 @@ impl From<Params> for Parameters<Engine> {
 #[wasm_bindgen]
 impl Params {
     #[wasm_bindgen(js_name = "fromBinary")]
-    pub fn from_binary(input: &[u8]) -> Result<Params, JsValue> {
-        Self::from_binary_ext(input, true, true)
+    pub fn from_binary(input: &[u8], precompute: bool) -> Result<Params, JsValue> {
+        Self::from_binary_ext(input, true, true, precompute)
     }
 
     #[wasm_bindgen(js_name = "fromBinaryExtended")]
-    pub fn from_binary_ext(input: &[u8], disallow_points_at_infinity: bool, checked: bool) -> Result<Params, JsValue> {
+    pub fn from_binary_ext(input: &[u8], disallow_points_at_infinity: bool, checked: bool, precompute: bool) -> Result<Params, JsValue> {
         let mut input = input;
         let inner = Parameters::read(&mut input, disallow_points_at_infinity, checked).map_err(|err| js_err!("{}", err))?;
+        let mut precomputed = None;
 
-        Ok(Params { inner })
+        if precompute {
+            if let Ok(precompute_memory_size) = inner.precompute_memory_size() {
+                {
+                    // WebAssembly.Memory.grow(..) is extremely slow on iOS 
+                    // so it's much better to allocate necessary memory with one call 
+                    // than to do it multiple times in precompute.
+                    let mut v: Vec<u8> = Vec::new();
+                    v.reserve(precompute_memory_size);
+                    v.shrink_to_fit()
+                }
+                precomputed = Some(inner.precompute());
+            }
+        }
+
+        Ok(Params { inner, precomputed })  
     }
 }

--- a/libzkbob-rs-wasm/src/proof.rs
+++ b/libzkbob-rs-wasm/src/proof.rs
@@ -1,3 +1,4 @@
+use fawkes_crypto::backend::bellman_groth16::prover::prove_precomputed;
 use libzkbob_rs::libzeropool::{
     circuit::tree::tree_update,
     circuit::tx::c_transfer,
@@ -45,6 +46,7 @@ impl Proof {
         transfer_pub: ts_types::TransferPub,
         transfer_sec: ts_types::TransferSec,
     ) -> Result<crate::ts_types::Proof, JsValue> {
+        let precomputed = &params.precomputed;
         let params = &params.inner;
 
         let public: NativeTransferPub<_> =
@@ -56,7 +58,10 @@ impl Proof {
             c_transfer(&public, &secret, &*POOL_PARAMS);
         };
 
-        let (inputs, snark_proof) = prove(params, &public, &secret, circuit);
+        let (inputs, snark_proof) = match precomputed {
+            Some(precomputed) => prove_precomputed(params, &public, &secret, circuit, precomputed),
+            None => prove(params, &public, &secret, circuit)
+        };
 
         let proof = Proof {
             inputs,

--- a/libzkbob-rs/src/proof.rs
+++ b/libzkbob-rs/src/proof.rs
@@ -4,8 +4,8 @@ use libzeropool::{
     },
     fawkes_crypto::{
         backend::bellman_groth16::engines::Engine,
-        backend::bellman_groth16::prover::{prove, Proof},
-        backend::bellman_groth16::Parameters,
+        backend::bellman_groth16::{prover::{prove, Proof}, PrecomputedData},
+        backend::bellman_groth16::{Parameters, prover::prove_precomputed},
         ff_uint::Num,
     },
     native::{
@@ -33,6 +33,24 @@ where
     prove(params, &transfer_pub, &transfer_sec, circuit)
 }
 
+pub fn prove_tx_precomputed<P, E>(
+    params: &Parameters<E>,
+    pool_params: &P,
+    transfer_pub: TransferPub<E::Fr>,
+    transfer_sec: TransferSec<E::Fr>,
+    precomputed: &PrecomputedData<E::Fr>,
+) -> (Vec<Num<E::Fr>>, Proof<E>)
+where
+    P: PoolParams<Fr = E::Fr>,
+    E: Engine,
+{
+    let circuit = |public, secret| {
+        c_transfer(&public, &secret, pool_params);
+    };
+
+    prove_precomputed(params, &transfer_pub, &transfer_sec, circuit, precomputed)
+}
+
 pub fn prove_tree<P, E>(
     params: &Parameters<E>,
     pool_params: &P,
@@ -50,6 +68,24 @@ where
     prove(params, &tree_pub, &tree_sec, circuit)
 }
 
+pub fn prove_tree_precomputed<P, E>(
+    params: &Parameters<E>,
+    pool_params: &P,
+    tree_pub: TreePub<E::Fr>,
+    tree_sec: TreeSec<E::Fr>,
+    precomputed: &PrecomputedData<E::Fr>,
+) -> (Vec<Num<E::Fr>>, Proof<E>)
+where
+    P: PoolParams<Fr = E::Fr>,
+    E: Engine,
+{
+    let circuit = |public, secret| {
+        tree_update(&public, &secret, pool_params);
+    };
+
+    prove_precomputed(params, &tree_pub, &tree_sec, circuit, precomputed)
+}
+
 pub fn prove_delegated_deposit<P, E>(
     params: &Parameters<E>,
     pool_params: &P,
@@ -65,5 +101,23 @@ where
     };
 
     prove(params, &d_pub, &d_sec, circuit)
+}
+
+pub fn prove_delegated_deposit_precomputed<P, E>(
+    params: &Parameters<E>,
+    pool_params: &P,
+    d_pub: DelegatedDepositBatchPub<E::Fr>,
+    d_sec: DelegatedDepositBatchSec<E::Fr>,
+    precomputed: &PrecomputedData<E::Fr>,
+) -> (Vec<Num<E::Fr>>, Proof<E>)
+where
+    P: PoolParams<Fr = E::Fr>,
+    E: Engine,
+{
+    let circuit = |public, secret| {
+        check_delegated_deposit_batch(&public, &secret, pool_params);
+    };
+
+    prove_precomputed(params, &d_pub, &d_sec, circuit, precomputed)
 }
 

--- a/libzkbob-rs/src/proof.rs
+++ b/libzkbob-rs/src/proof.rs
@@ -21,6 +21,7 @@ pub fn prove_tx<P, E>(
     pool_params: &P,
     transfer_pub: TransferPub<E::Fr>,
     transfer_sec: TransferSec<E::Fr>,
+    precomputed: &Option<PrecomputedData<E::Fr>>,
 ) -> (Vec<Num<E::Fr>>, Proof<E>)
 where
     P: PoolParams<Fr = E::Fr>,
@@ -30,25 +31,12 @@ where
         c_transfer(&public, &secret, pool_params);
     };
 
-    prove(params, &transfer_pub, &transfer_sec, circuit)
-}
-
-pub fn prove_tx_precomputed<P, E>(
-    params: &Parameters<E>,
-    pool_params: &P,
-    transfer_pub: TransferPub<E::Fr>,
-    transfer_sec: TransferSec<E::Fr>,
-    precomputed: &PrecomputedData<E::Fr>,
-) -> (Vec<Num<E::Fr>>, Proof<E>)
-where
-    P: PoolParams<Fr = E::Fr>,
-    E: Engine,
-{
-    let circuit = |public, secret| {
-        c_transfer(&public, &secret, pool_params);
-    };
-
-    prove_precomputed(params, &transfer_pub, &transfer_sec, circuit, precomputed)
+    match precomputed {
+        Some(precomputed) => {
+            prove_precomputed(params, &transfer_pub, &transfer_sec, circuit, precomputed)
+        },
+        None => prove(params, &transfer_pub, &transfer_sec, circuit)
+    }
 }
 
 pub fn prove_tree<P, E>(
@@ -56,6 +44,7 @@ pub fn prove_tree<P, E>(
     pool_params: &P,
     tree_pub: TreePub<E::Fr>,
     tree_sec: TreeSec<E::Fr>,
+    precomputed: &Option<PrecomputedData<E::Fr>>,
 ) -> (Vec<Num<E::Fr>>, Proof<E>)
 where
     P: PoolParams<Fr = E::Fr>,
@@ -65,25 +54,12 @@ where
         tree_update(&public, &secret, pool_params);
     };
 
-    prove(params, &tree_pub, &tree_sec, circuit)
-}
-
-pub fn prove_tree_precomputed<P, E>(
-    params: &Parameters<E>,
-    pool_params: &P,
-    tree_pub: TreePub<E::Fr>,
-    tree_sec: TreeSec<E::Fr>,
-    precomputed: &PrecomputedData<E::Fr>,
-) -> (Vec<Num<E::Fr>>, Proof<E>)
-where
-    P: PoolParams<Fr = E::Fr>,
-    E: Engine,
-{
-    let circuit = |public, secret| {
-        tree_update(&public, &secret, pool_params);
-    };
-
-    prove_precomputed(params, &tree_pub, &tree_sec, circuit, precomputed)
+    match precomputed {
+        Some(precomputed) => {
+            prove_precomputed(params, &tree_pub, &tree_sec, circuit, precomputed)
+        },
+        None => prove(params, &tree_pub, &tree_sec, circuit)
+    }
 }
 
 pub fn prove_delegated_deposit<P, E>(
@@ -91,6 +67,7 @@ pub fn prove_delegated_deposit<P, E>(
     pool_params: &P,
     d_pub: DelegatedDepositBatchPub<E::Fr>,
     d_sec: DelegatedDepositBatchSec<E::Fr>,
+    precomputed: &Option<PrecomputedData<E::Fr>>,
 ) -> (Vec<Num<E::Fr>>, Proof<E>)
 where
     P: PoolParams<Fr = E::Fr>,
@@ -100,24 +77,10 @@ where
         check_delegated_deposit_batch(&public, &secret, pool_params);
     };
 
-    prove(params, &d_pub, &d_sec, circuit)
+    match precomputed {
+        Some(precomputed) => {
+            prove_precomputed(params, &d_pub, &d_sec, circuit, precomputed)
+        },
+        None => prove(params, &d_pub, &d_sec, circuit)
+    }
 }
-
-pub fn prove_delegated_deposit_precomputed<P, E>(
-    params: &Parameters<E>,
-    pool_params: &P,
-    d_pub: DelegatedDepositBatchPub<E::Fr>,
-    d_sec: DelegatedDepositBatchSec<E::Fr>,
-    precomputed: &PrecomputedData<E::Fr>,
-) -> (Vec<Num<E::Fr>>, Proof<E>)
-where
-    P: PoolParams<Fr = E::Fr>,
-    E: Engine,
-{
-    let circuit = |public, secret| {
-        check_delegated_deposit_batch(&public, &secret, pool_params);
-    };
-
-    prove_precomputed(params, &d_pub, &d_sec, circuit, precomputed)
-}
-


### PR DESCRIPTION
This pull request adds the feature to decompress and parse gates prior to the proving process. The reason why this can be useful is described in the https://github.com/zkBob/fawkes-crypto/issues/12.

**libzkbob-rs-wasm**
This PR adds an extra flag called `precompute` to the existing `Params.fromBinary` and `Params.fromBinaryExtended` methods.  If the `precompute` flag is set to true, the `fromBinary` and `fromBinaryExtended` methods will decompress and parse the gates, which can lead to a faster proving process. However, this also means that the application will consume an additional 260 MB of RAM.

**libzkbob-rs-node**
This PR adds an extra flag called `precompute` to the existing `Params.fromBinary` and `Params.fromFile` methods. If the `precompute` flag is set to true, the `fromBinary` and `fromFile` methods will decompress and parse the gates, which can lead to a faster proving process. However, this also means that the application will consume an additional 1100 MB of RAM (direct deposit circuit is ten times as large).