### PR TITLE
Multipool addresses support

### DIFF
--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs-wasm"
 description = "A higher level zkBob API for Wasm"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs-wasm/src/client/mod.rs
+++ b/libzkbob-rs-wasm/src/client/mod.rs
@@ -68,10 +68,10 @@ impl UserAccount {
     pub fn new(sk: &[u8], pool_id: u32, state: UserState, network: &str) -> Result<UserAccount, JsValue> {
         crate::utils::set_panic_hook();
 
-        let pool = if network.to_lowercase() == "sepolia" && pool_id == Pool::Sepolia.pool_id() {
+        let pool = if network.to_lowercase() == "sepolia" && pool_id == Pool::SepoliaBOB.pool_id() {
             // A workaround related with Sepolia pool_id issue
             // (pool_id for Sepolia BOB pool is equal to Polygon BOB pool)
-            Ok(Pool::Sepolia)
+            Ok(Pool::SepoliaBOB)
         } else {
             Pool::from_pool_id(pool_id)
                 .ok_or_else(|| js_err!("Unsupported pool with ID {}", pool_id))
@@ -122,6 +122,14 @@ impl UserAccount {
         let p_d = Num::from_str(p_d).unwrap();
 
         self.inner.borrow().generate_address_from_components(d, p_d)
+    }
+
+    #[wasm_bindgen(js_name = "convertAddressToChainSpecific")]
+    pub fn convert_address_to_chain_specific(&self, address: &str) -> Result<String, JsValue> {
+        let (d, p_d, _) = 
+            parse_address::<PoolParams>(address, &POOL_PARAMS).map_err(|err| js_err!(&err.to_string()))?;
+
+        Ok(self.inner.borrow().generate_address_from_components(d, p_d))
     }
 
     #[wasm_bindgen(js_name = "parseAddress")]

--- a/libzkbob-rs-wasm/src/keys.rs
+++ b/libzkbob-rs-wasm/src/keys.rs
@@ -1,33 +1,10 @@
-use libzkbob_rs::{address::format_address, keys::reduce_sk as reduce_sk_native};
-use libzkbob_rs::libzeropool::{
-    constants,
-    fawkes_crypto::{ff_uint::Uint, rand::Rng},
-    native::{boundednum::BoundedNum, key::derive_key_p_d},
-    POOL_PARAMS,
-};
+use libzkbob_rs::{ keys::reduce_sk as reduce_sk_native};
+use libzkbob_rs::libzeropool::fawkes_crypto::ff_uint::Uint;
 use wasm_bindgen::prelude::*;
 
-use crate::{Fs, PoolParams};
+use crate::Fs;
 
 #[wasm_bindgen(js_name = reduceSpendingKey)]
 pub fn reduce_sk(seed: &[u8]) -> Vec<u8> {
     reduce_sk_native::<Fs>(seed).to_uint().0.to_little_endian()
-}
-
-#[wasm_bindgen(js_name = genBurnerAddress)]
-pub fn gen_burner_address(pool_id: u64, seed: &[u8]) -> Result<String, JsValue> {
-    if pool_id >= 1 << 24 {
-        return Err(js_err!("PoolID should be less than {}", 1 << 24));
-    }
-    let mut rng = libzkbob_rs::random::CustomRng;
-
-    let sk = reduce_sk_native::<Fs>(seed);
-
-    let keys = libzkbob_rs::keys::Keys::derive(sk, &*POOL_PARAMS);
-
-    let d: BoundedNum<_, { constants::DIVERSIFIER_SIZE_BITS }> = rng.gen();
-
-    let pk_d = derive_key_p_d(d.to_num(), keys.eta, &*POOL_PARAMS);
-
-    Ok(format_address::<PoolParams>(d, pk_d.x))
 }

--- a/libzkbob-rs-wasm/src/lib.rs
+++ b/libzkbob-rs-wasm/src/lib.rs
@@ -1,15 +1,11 @@
-use std::str::FromStr;
-
 use libzkbob_rs::libzeropool::{
     constants,
-    fawkes_crypto::{backend::bellman_groth16::engines::Bn256, ff_uint::Num},
+    fawkes_crypto::{backend::bellman_groth16::engines::Bn256},
     native::{
-        boundednum::BoundedNum,
         params::{PoolBN256, PoolParams as PoolParamsTrait},
     },
     POOL_PARAMS,
 };
-use libzkbob_rs::address::{format_address, parse_address};
 use serde::Serialize;
 use wasm_bindgen::{prelude::*, JsCast};
 
@@ -72,38 +68,4 @@ pub fn get_constants() -> Constants {
     serde_wasm_bindgen::to_value(&*CONSTANTS)
         .unwrap()
         .unchecked_into::<Constants>()
-}
-
-#[wasm_bindgen(js_name = "validateAddress")]
-pub fn validate_address(address: &str) -> bool {
-    parse_address::<PoolParams>(address, &POOL_PARAMS).is_ok()
-}
-
-#[wasm_bindgen(js_name = "assembleAddress")]
-pub fn assemble_address(d: &str, p_d: &str) -> String {
-    let d = Num::from_str(d).unwrap();
-    let d = BoundedNum::new(d);
-    let p_d = Num::from_str(p_d).unwrap();
-
-    format_address::<PoolParams>(d, p_d)
-}
-
-#[wasm_bindgen(js_name = "parseAddress")]
-pub fn parse_address_(address: &str) -> IAddressComponents {
-    let (d, p_d) = parse_address::<PoolParams>(address, &POOL_PARAMS).unwrap();
-
-    #[derive(Serialize)]
-    struct Address {
-        d: String,
-        p_d: String,
-    }
-
-    let address = Address {
-        d: d.to_num().to_string(),
-        p_d: p_d.to_string(),
-    };
-
-    serde_wasm_bindgen::to_value(&address)
-        .unwrap()
-        .unchecked_into::<IAddressComponents>()
 }

--- a/libzkbob-rs-wasm/src/ts_types.rs
+++ b/libzkbob-rs-wasm/src/ts_types.rs
@@ -109,6 +109,8 @@ export interface IAddressComponents {
     d: string;
     p_d: string;
     pool_id: string;
+    checksum: Uint8Array;
+    format: string;
 }
 
 export interface ITxBaseFields {

--- a/libzkbob-rs-wasm/src/ts_types.rs
+++ b/libzkbob-rs-wasm/src/ts_types.rs
@@ -108,6 +108,7 @@ export interface VK {
 export interface IAddressComponents {
     d: string;
     p_d: string;
+    pool_id: string;
 }
 
 export interface ITxBaseFields {

--- a/libzkbob-rs-wasm/src/ts_types.rs
+++ b/libzkbob-rs-wasm/src/ts_types.rs
@@ -106,11 +106,13 @@ export interface VK {
 }
 
 export interface IAddressComponents {
+    format: string;
     d: string;
     p_d: string;
-    pool_id: string;
     checksum: Uint8Array;
-    format: string;
+    pool_id: string;
+    derived_from_our_sk: boolean;
+    is_pool_valid: boolean;
 }
 
 export interface ITxBaseFields {

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs"
 description = "A higher level zkBob API"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/src/address.rs
+++ b/libzkbob-rs/src/address.rs
@@ -128,7 +128,7 @@ pub fn parse_address_ext<P: PoolParams>(
         }
 
         // the old format should be acceptable on the Polygon BOB pool only
-        return Ok((d, p_d, Some(Pool::Polygon), AddressFormat::Old, checksum));
+        return Ok((d, p_d, Some(Pool::PolygonBOB), AddressFormat::Old, checksum));
     }
 }
 

--- a/libzkbob-rs/src/address.rs
+++ b/libzkbob-rs/src/address.rs
@@ -1,5 +1,7 @@
-use crate::utils::keccak256;
-use crate::client::POOL_ID_BITS;
+use std::convert::TryInto;
+
+use crate::pools::Pool;
+use crate::{utils::keccak256, pools::{GENERIC_ADDRESS_PREFIX, POOL_ID_BITS}};
 use libzeropool::{
     constants,
     fawkes_crypto::{
@@ -15,6 +17,10 @@ const ADDR_LEN: usize = 46;
 
 #[derive(Error, Debug)]
 pub enum AddressParseError {
+    #[error("Invalid format")]
+    InvalidFormat,
+    #[error("Invalid prefix {0}")]
+    InvalidPrefix(String),
     #[error("Invalid checksum")]
     InvalidChecksum,
     #[error("Pd does not belongs prime subgroup")]
@@ -30,31 +36,91 @@ pub fn parse_address<P: PoolParams>(
     params: &P,
 ) -> Result<
     (
-        BoundedNum<P::Fr, { constants::DIVERSIFIER_SIZE_BITS }>,
-        Num<P::Fr>,
+        BoundedNum<P::Fr, { constants::DIVERSIFIER_SIZE_BITS }>, // d
+        Num<P::Fr>, // p_d
+        Option<Pool>,   // None for generic and old addresses
+    ),
+    AddressParseError,
+>{
+    if address.find(':').is_some() {
+        // address with prefix
+        let addr_components: Vec<&str> = address.split(':').collect();  
+        if addr_components.len() == 2 {
+            let pool = Pool::from_prefix(addr_components[0]);
+            let (d,
+                p_d,
+                addr_hash,
+                checksum) = parse_address_raw(addr_components[1], params)?;
+
+            match pool {
+                Some(pool) => {
+                    // pool-specific address
+                    const POOL_ID_BYTES: usize = POOL_ID_BITS >> 3;
+                    let mut hash_src: [u8; POOL_ID_BYTES + 32] = [0; POOL_ID_BYTES + 32];
+                    pool.pool_id().serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
+                    hash_src[POOL_ID_BYTES..POOL_ID_BYTES + 32].clone_from_slice(&keccak256(&addr_hash));
+
+                    if keccak256(&hash_src)[0..=3] != checksum {
+                        return Err(AddressParseError::InvalidChecksum);
+                    }
+                    return Ok((d, p_d, None));
+                },
+                None => {
+                    if addr_components[0].to_lowercase() == GENERIC_ADDRESS_PREFIX {
+                        // generic address
+                        if &addr_hash[0..=3] != checksum {
+                            return Err(AddressParseError::InvalidChecksum);
+                        }
+                        return Ok((d, p_d, None));
+                    } else {
+                        return Err(AddressParseError::InvalidPrefix(addr_components[0].to_string()))
+                    }
+                },
+            };
+        }
+
+        return Err(AddressParseError::InvalidFormat);
+    } else {
+        // old format without prefix
+        let (d,
+            p_d,
+            addr_hash,
+            checksum) = parse_address_raw(address, params)?;
+        
+        if &addr_hash[0..=3] != checksum {
+            return Err(AddressParseError::InvalidChecksum);
+        }
+
+        return Ok((d, p_d, None));
+    }
+}
+
+fn parse_address_raw<P: PoolParams>(
+    raw_address: &str,
+    params: &P,
+) -> Result<
+    (
+        BoundedNum<P::Fr, { constants::DIVERSIFIER_SIZE_BITS }>, // d
+        Num<P::Fr>, // p_d
+        [u8; 32],   // keccak256(d ++ p_d)
+        [u8; 4],    // checksum (not checked, just extracted)
     ),
     AddressParseError,
 >{
     let mut bytes = [0; ADDR_LEN];
-    bs58::decode(address).into(&mut bytes)?;
-
-    let checksum = &bytes[42..=45];
-
-    let hash = keccak256(&bytes[0..=41]);
-
-    if &hash[0..=3] != checksum {
-        return Err(AddressParseError::InvalidChecksum);
-    }
+    bs58::decode(raw_address).into(&mut bytes)?;
 
     let d = BoundedNum::try_from_slice(&bytes[0..10])?;
     let p_d = Num::try_from_slice(&bytes[10..42])?;
+    let checksum = bytes[42..=45].try_into().unwrap();
 
     match EdwardsPoint::subgroup_decompress(p_d, params.jubjub()) {
-        Some(_) => Ok((d, p_d)),
+        Some(_) => Ok((d, p_d, keccak256(&bytes[0..=41]), checksum)),
         None => Err(AddressParseError::InvalidNumber)
     }
 }
 
+// generates shielded address in format "pool_prefix:base58(d ++ p_d ++ checksum)"
 pub fn format_address<P: PoolParams>(
     d: BoundedNum<P::Fr, { constants::DIVERSIFIER_SIZE_BITS }>,
     p_d: Num<P::Fr>,
@@ -65,22 +131,30 @@ pub fn format_address<P: PoolParams>(
     d.serialize(&mut &mut buf[0..10]).unwrap();
     p_d.serialize(&mut &mut buf[10..42]).unwrap();
 
-    let raw_addr_hash = keccak256(&buf[0..42]);
-
-    let checksum_hash = match pool_id {
-        // pool-specific format
+    // there are two ways for checksum calculation
+    let (checksum_hash, address_prefix) = match pool_id {
+        // pool-specific format...
         Some(pool_id) => {
-            let mut hash_src: [u8; POOL_ID_BITS + 32] = [0; POOL_ID_BITS + 32];
-            pool_id.serialize(& mut &mut hash_src[0..(POOL_ID_BITS >> 3)]).unwrap();
-            hash_src[(POOL_ID_BITS >> 3)..POOL_ID_BITS + 32].clone_from_slice(&keccak256(&buf[0..42]));
-            keccak256(&hash_src)
+            match Pool::from_pool_id(pool_id.to_num().try_into().unwrap()) {
+                // ...is available only for known pools
+                Some(p) => {
+                    const POOL_ID_BYTES: usize = POOL_ID_BITS >> 3;
+                    let mut hash_src: [u8; POOL_ID_BYTES + 32] = [0; POOL_ID_BYTES + 32];
+                    pool_id.serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
+                    hash_src[POOL_ID_BYTES..POOL_ID_BYTES + 32].clone_from_slice(&keccak256(&buf[0..42]));
+                    (keccak256(&hash_src), p.address_prefix().to_owned())
+                },
+                // ...otherwise fallback to the generic address
+                None => (keccak256(&buf[0..42]), GENERIC_ADDRESS_PREFIX.to_string()),
+            }
         },
-        // generic format
-        None => keccak256(&buf[0..42]),
+        // generic format (for all pools, when pool_id isn't specified)
+        None => (keccak256(&buf[0..42]), GENERIC_ADDRESS_PREFIX.to_string()),
     };
     buf[42..ADDR_LEN].clone_from_slice(&checksum_hash[0..4]);
 
+    let address_part = bs58::encode(buf).into_string();
 
+    format!("{}:{}", address_prefix, address_part)
 
-    bs58::encode(buf).into_string()
 }

--- a/libzkbob-rs/src/address.rs
+++ b/libzkbob-rs/src/address.rs
@@ -91,9 +91,7 @@ pub fn parse_address_ext<P: PoolParams>(
                     // pool-specific address
                     const POOL_ID_BYTES: usize = POOL_ID_BITS >> 3;
                     let mut hash_src: [u8; POOL_ID_BYTES + 32] = [0; POOL_ID_BYTES + 32];
-                    let pool_id = pool.pool_id_num::<P::Fr>().to_num().to_uint().0.to_big_endian();
-                    let pool_id_be: [u8; POOL_ID_BYTES] = pool_id[32 - POOL_ID_BYTES..32].try_into().unwrap();
-                    pool_id_be.serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
+                    pool.pool_id_bytes_be::<P::Fr>().serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
                     hash_src[POOL_ID_BYTES..POOL_ID_BYTES + 32].clone_from_slice(&addr_hash);
 
                     if keccak256(&hash_src)[0..=3] != checksum {
@@ -174,9 +172,9 @@ pub fn format_address<P: PoolParams>(
         Some(pool) => {
             const POOL_ID_BYTES: usize = POOL_ID_BITS >> 3;
             let mut hash_src: [u8; POOL_ID_BYTES + 32] = [0; POOL_ID_BYTES + 32];
-            let pool_id = pool.pool_id_num::<P::Fr>().to_num().to_uint().0.to_big_endian();
-            let pool_id_be: [u8; POOL_ID_BYTES] = pool_id[32 - POOL_ID_BYTES..32].try_into().unwrap();
-            pool_id_be.serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
+            //let pool_id = pool.pool_id_num::<P::Fr>().to_num().to_uint().0.to_big_endian();
+            //let pool_id_be: [u8; POOL_ID_BYTES] = pool_id[32 - POOL_ID_BYTES..32].try_into().unwrap();
+            pool.pool_id_bytes_be::<P::Fr>().serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
             hash_src[POOL_ID_BYTES..POOL_ID_BYTES + 32].clone_from_slice(&keccak256(&buf[0..42]));
             (keccak256(&hash_src), pool.address_prefix().to_owned())
         },

--- a/libzkbob-rs/src/address.rs
+++ b/libzkbob-rs/src/address.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use std::convert::{TryInto};
 
 use crate::pools::Pool;
 use crate::{utils::keccak256, pools::{GENERIC_ADDRESS_PREFIX, POOL_ID_BITS}};
@@ -57,8 +57,8 @@ pub fn parse_address<P: PoolParams>(
                     // pool-specific address
                     const POOL_ID_BYTES: usize = POOL_ID_BITS >> 3;
                     let mut hash_src: [u8; POOL_ID_BYTES + 32] = [0; POOL_ID_BYTES + 32];
-                    pool.pool_id().serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
-                    hash_src[POOL_ID_BYTES..POOL_ID_BYTES + 32].clone_from_slice(&keccak256(&addr_hash));
+                    pool.pool_id_num::<P::Fr>().serialize(& mut &mut hash_src[0..POOL_ID_BYTES]).unwrap();
+                    hash_src[POOL_ID_BYTES..POOL_ID_BYTES + 32].clone_from_slice(&addr_hash);
 
                     if keccak256(&hash_src)[0..=3] != checksum {
                         return Err(AddressParseError::InvalidChecksum);

--- a/libzkbob-rs/src/address.rs
+++ b/libzkbob-rs/src/address.rs
@@ -104,7 +104,7 @@ pub fn parse_address_ext<P: PoolParams>(
                 None => {
                     if addr_components[0].to_lowercase() == GENERIC_ADDRESS_PREFIX {
                         // generic address
-                        if &addr_hash[0..=3] != checksum {
+                        if addr_hash[0..=3] != checksum {
                             return Err(AddressParseError::InvalidChecksum);
                         }
                         return Ok((d, p_d, None, AddressFormat::Generic, checksum));
@@ -115,7 +115,7 @@ pub fn parse_address_ext<P: PoolParams>(
             };
         }
 
-        return Err(AddressParseError::InvalidFormat);
+        Err(AddressParseError::InvalidFormat)
     } else {
         // old format without prefix
         let (d,
@@ -123,12 +123,12 @@ pub fn parse_address_ext<P: PoolParams>(
             addr_hash,
             checksum) = parse_address_raw(address, params)?;
         
-        if &addr_hash[0..=3] != checksum {
+        if addr_hash[0..=3] != checksum {
             return Err(AddressParseError::InvalidChecksum);
         }
 
         // the old format should be acceptable on the Polygon BOB pool only
-        return Ok((d, p_d, Some(Pool::PolygonBOB), AddressFormat::Old, checksum));
+        Ok((d, p_d, Some(Pool::PolygonBOB), AddressFormat::Old, checksum))
     }
 }
 

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -37,6 +37,8 @@ use crate::{
 
 pub mod state;
 
+
+
 #[derive(Debug, Error)]
 pub enum CreateTxError {
     #[error("Too many outputs: expected {max} max got {got}")]
@@ -106,8 +108,10 @@ pub enum TxType<Fr: PrimeField> {
     ),
 }
 
+pub const POOL_ID_BITS: usize = 24;
+
 pub struct UserAccount<D: KeyValueDB, P: PoolParams> {
-    pub pool_id: BoundedNum<P::Fr, { constants::DIVERSIFIER_SIZE_BITS }>,
+    pub pool_id: BoundedNum<P::Fr, { POOL_ID_BITS }>,
     pub keys: Keys<P>,
     pub params: P,
     pub state: State<D, P>,

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -613,7 +613,7 @@ mod tests {
     #[test]
     fn test_create_tx_deposit_zero() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::Polygon, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
 
         acc.create_tx(
             TxType::Deposit(
@@ -630,7 +630,7 @@ mod tests {
     #[test]
     fn test_create_tx_deposit_one() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::Polygon, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
 
         acc.create_tx(
             TxType::Deposit(
@@ -648,7 +648,7 @@ mod tests {
     #[test]
     fn test_create_tx_transfer_zero() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::Polygon, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
 
         let addr = acc.generate_address();
 
@@ -669,7 +669,7 @@ mod tests {
     #[should_panic]
     fn test_create_tx_transfer_one_no_balance() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::Polygon, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
 
         let addr = acc.generate_address();
 
@@ -690,13 +690,13 @@ mod tests {
     fn test_user_account_is_own_address() {
         let acc_1 = UserAccount::new(
             Num::ZERO,
-            Pool::Goerli,
+            Pool::GoerliBOB,
             State::init_test(POOL_PARAMS.clone()),
             POOL_PARAMS.clone(),
         );
         let acc_2 = UserAccount::new(
             Num::ONE,
-            Pool::Goerli,
+            Pool::GoerliBOB,
             State::init_test(POOL_PARAMS.clone()),
             POOL_PARAMS.clone(),
         );
@@ -713,9 +713,10 @@ mod tests {
 
     #[test]
     fn test_chain_specific_addresses() {
-        let acc_polygon = UserAccount::new(Num::ZERO, Pool::Polygon, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
-        let acc_sepolia = UserAccount::new(Num::ZERO, Pool::Sepolia, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
-        let acc_optimism = UserAccount::new(Num::ZERO, Pool::Optimism, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc_polygon = UserAccount::new(Num::ZERO, Pool::PolygonBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc_sepolia = UserAccount::new(Num::ZERO, Pool::SepoliaBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc_optimism = UserAccount::new(Num::ZERO, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc_optimism_eth = UserAccount::new(Num::ZERO, Pool::OptimismETH, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
 
         assert!(acc_polygon.validate_address("PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5kxBwa"));
         assert!(acc_polygon.validate_address("zkbob:PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5kxBwa"));
@@ -742,18 +743,25 @@ mod tests {
         assert!(!acc_optimism.validate_address(":"));
         assert!(!acc_optimism.validate_address(""));
 
+        assert!(!acc_optimism_eth.validate_address("PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5kxBwa"));
+        assert!(acc_optimism_eth.validate_address("zkbob:PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5kxBwa"));
+        assert!(acc_optimism_eth.validate_address("zkbob_optimism_eth:PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse1j9diw"));
+        assert!(!acc_optimism_eth.validate_address("zkbob_polygon:PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5kRF7i"));
+        assert!(!acc_optimism_eth.validate_address("zkbob_optimism:PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5vHs5L"));
+        assert!(!acc_optimism_eth.validate_address("zkbob_optimism_eth:PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5kRF7i"));
     }   
 
     #[test]
     fn test_chain_specific_address_ownable() {
         let accs = [
-            UserAccount::new(Num::ZERO, Pool::Polygon, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
-            UserAccount::new(Num::ZERO, Pool::Optimism, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
-            UserAccount::new(Num::ZERO, Pool::Sepolia, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
-            UserAccount::new(Num::ZERO, Pool::Goerli, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
-            UserAccount::new(Num::ZERO, Pool::GoerliOptimism, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::PolygonBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::OptimismETH, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::SepoliaBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::GoerliBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::GoerliOptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
         ];
-        let acc2 = UserAccount::new(Num::ONE, Pool::Optimism, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc2 = UserAccount::new(Num::ONE, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
         let pool_addresses: Vec<String> = accs.iter().map(|acc| acc.generate_address()).collect();
         let universal_addresses: Vec<String> = accs.iter().map(|acc| acc.generate_universal_address()).collect();
 

--- a/libzkbob-rs/src/delegated_deposit.rs
+++ b/libzkbob-rs/src/delegated_deposit.rs
@@ -170,14 +170,7 @@ impl<Fr: PrimeField> DelegatedDepositData<Fr> {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
-
-    use libzeropool::{
-        fawkes_crypto::backend::bellman_groth16::{engines::Bn256, verifier::verify, Parameters},
-        POOL_PARAMS,
-    };
-
     use super::*;
-    use crate::proof::prove_delegated_deposit;
 
     #[test]
     fn test_delegated_deposit_data_create_full() {

--- a/libzkbob-rs/src/lib.rs
+++ b/libzkbob-rs/src/lib.rs
@@ -1,5 +1,6 @@
 pub use libzeropool;
 
+pub mod pools;
 pub mod address;
 pub mod client;
 pub mod delegated_deposit;

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -1,5 +1,8 @@
 use std::fmt;
 
+use libzeropool::native::boundednum::BoundedNum;
+use libzeropool::fawkes_crypto::ff_uint::{PrimeField, Uint, NumRepr, Num};
+
 
 
 pub const POOL_ID_BITS: usize = 24;
@@ -48,6 +51,13 @@ impl Pool {
             Pool::Goerli => 0xffff02,
             Pool::GoerliOptimism => 0xffff03,
         }
+    }
+
+    pub fn pool_id_num<Fr: PrimeField>(&self) -> BoundedNum<Fr, POOL_ID_BITS> {
+        let pool_id = self.pool_id();
+        let pool_id_num = Num::<Fr>::from_uint(NumRepr(Uint::from_u64(pool_id as u64))).unwrap();
+
+        BoundedNum::new(pool_id_num)
     }
 
     pub fn address_prefix(&self) -> &str {

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -13,44 +13,50 @@ pub const GENERIC_ADDRESS_PREFIX: &str = "zkbob";
 // It used to support multipool shielded addresses
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Pool {
-    Polygon,
-    Optimism,
-    Sepolia,
-    Goerli,
-    GoerliOptimism,
+    PolygonBOB,
+    OptimismBOB,
+    OptimismETH,
+    SepoliaBOB,
+    GoerliBOB,
+    GoerliOptimismBOB,
 }
 
 impl Pool {
     pub fn from_pool_id(pool_id: u32) -> Option<Pool> {
         match pool_id {
-            0x000000 => Some(Pool::Polygon),
-            0x000001 => Some(Pool::Optimism),
-            //0x000000 => Some(Pool::Sepolia),  // pool_id duplication, use this method with caution
-            0xffff02 => Some(Pool::Goerli),
-            0xffff03 => Some(Pool::GoerliOptimism),
+            0x000000 => Some(Pool::PolygonBOB),
+            0x000001 => Some(Pool::OptimismBOB),
+            0x000002 => Some(Pool::OptimismETH),
+            // pool_id duplication, use this method with caution
+            // (it will never produce Pool::SepoliaBOB object)
+            //0x000000 => Some(Pool::SepoliaBOB),
+            0xffff02 => Some(Pool::GoerliBOB),
+            0xffff03 => Some(Pool::GoerliOptimismBOB),
             _ => None,
         }
     }
 
     pub fn from_prefix(address_prefix: &str) -> Option<Pool> {
         match address_prefix.to_lowercase().as_str() {
-            "zkbob_polygon" => Some(Pool::Polygon),
-            "zkbob_optimism" => Some(Pool::Optimism),
-            "zkbob_sepolia" => Some(Pool::Sepolia),
-            "zkbob_goerli" => Some(Pool::Goerli),
-            "zkbob_goerli_optimism" => Some(Pool::GoerliOptimism),
+            "zkbob_polygon" => Some(Pool::PolygonBOB),
+            "zkbob_optimism" => Some(Pool::OptimismBOB),
+            "zkbob_optimism_eth" => Some(Pool::OptimismETH),
+            "zkbob_sepolia" => Some(Pool::SepoliaBOB),
+            "zkbob_goerli" => Some(Pool::GoerliBOB),
+            "zkbob_goerli_optimism" => Some(Pool::GoerliOptimismBOB),
             _ => None,
         }
     }
 
     pub fn pool_id(&self) -> u32 {
         match self {
-            Pool::Polygon => 0x000000,
-            Pool::Optimism => 0x000001,
+            Pool::PolygonBOB => 0x000000,
+            Pool::OptimismBOB => 0x000001,
+            Pool::OptimismETH => 0x000002,
             // here is an issue with Sepolia pool deployment
-            Pool::Sepolia => 0x000000, 
-            Pool::Goerli => 0xffff02,
-            Pool::GoerliOptimism => 0xffff03,
+            Pool::SepoliaBOB => 0x000000, 
+            Pool::GoerliBOB => 0xffff02,
+            Pool::GoerliOptimismBOB => 0xffff03,
         }
     }
 
@@ -63,21 +69,23 @@ impl Pool {
 
     pub fn address_prefix(&self) -> &str {
         match self {
-            Pool::Polygon => "zkbob_polygon",
-            Pool::Optimism => "zkbob_optimism",
-            Pool::Sepolia => "zkbob_sepolia",
-            Pool::Goerli => "zkbob_goerli",
-            Pool::GoerliOptimism => "zkbob_goerli_optimism",
+            Pool::PolygonBOB => "zkbob_polygon",
+            Pool::OptimismBOB => "zkbob_optimism",
+            Pool::OptimismETH => "zkbob_optimism_eth",
+            Pool::SepoliaBOB => "zkbob_sepolia",
+            Pool::GoerliBOB => "zkbob_goerli",
+            Pool::GoerliOptimismBOB => "zkbob_goerli_optimism",
         }
     }
 
     pub fn human_readable(&self) -> &str {
         match self {
-            Pool::Polygon => "BOB on Polygon",
-            Pool::Optimism => "BOB on Optimism",
-            Pool::Sepolia => "BOB on Sepolia testnet",
-            Pool::Goerli => "BOB on Goerli testnet",
-            Pool::GoerliOptimism => "BOB on Goerli Optimism testnet",
+            Pool::PolygonBOB => "BOB on Polygon",
+            Pool::OptimismBOB => "BOB on Optimism",
+            Pool::OptimismETH => "ETH on Optimism",
+            Pool::SepoliaBOB => "BOB on Sepolia testnet",
+            Pool::GoerliBOB => "BOB on Goerli testnet",
+            Pool::GoerliOptimismBOB => "BOB on Goerli Optimism testnet",
         }
     }
 }

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -13,7 +13,7 @@ pub const GENERIC_ADDRESS_PREFIX: &str = "zkbob";
 // It used to support multipool shielded addresses
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Pool {
-    Polygon = 0,
+    Polygon,
     Optimism,
     Sepolia,
     Goerli,
@@ -45,9 +45,10 @@ impl Pool {
 
     pub fn pool_id(&self) -> u32 {
         match self {
-            Pool::Polygon => 0x00000,
-            Pool::Optimism => 0x00000,
-            Pool::Sepolia => 0x00000,
+            Pool::Polygon => 0x000000,
+            Pool::Optimism => 0x000001,
+            // here is an issue with Sepolia pool implementation
+            Pool::Sepolia => 0x000000, 
             Pool::Goerli => 0xffff02,
             Pool::GoerliOptimism => 0xffff03,
         }

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::fmt;
 
 use libzeropool::native::boundednum::BoundedNum;
@@ -65,6 +66,17 @@ impl Pool {
         let pool_id_num = Num::<Fr>::from_uint(NumRepr(Uint::from_u64(pool_id as u64))).unwrap();
 
         BoundedNum::new(pool_id_num)
+    }
+
+    pub fn pool_id_bytes_be<Fr: PrimeField>(&self) -> [u8; POOL_ID_BITS >> 3] {
+        const POOL_ID_BYTES: usize = POOL_ID_BITS >> 3;
+        let pool_id = self.pool_id();
+        let pool_id_num = Num::<Fr>::from_uint(NumRepr(Uint::from_u64(pool_id as u64))).unwrap();
+        
+        let pool_id_bytes = pool_id_num.to_uint().0.to_big_endian();
+        let pool_id_be: [u8; POOL_ID_BYTES] = pool_id_bytes[32 - POOL_ID_BYTES..32].try_into().unwrap();
+
+        pool_id_be
     }
 
     pub fn address_prefix(&self) -> &str {

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -70,16 +70,20 @@ impl Pool {
             Pool::GoerliOptimism => "zkbob_goerli_optimism",
         }
     }
+
+    pub fn human_readable(&self) -> &str {
+        match self {
+            Pool::Polygon => "BOB on Polygon",
+            Pool::Optimism => "BOB on Optimism",
+            Pool::Sepolia => "BOB on Sepolia testnet",
+            Pool::Goerli => "BOB on Goerli testnet",
+            Pool::GoerliOptimism => "BOB on Goerli Optimism testnet",
+        }
+    }
 }
 
 impl fmt::Display for Pool {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Pool::Polygon => write!(f, "BOB on Polygon"),
-            Pool::Optimism => write!(f, "BOB on Optimism"),
-            Pool::Sepolia => write!(f, "BOB on Sepolia testnet"),
-            Pool::Goerli => write!(f, "BOB on Goerli testnet"),
-            Pool::GoerliOptimism => write!(f, "BOB on Goerli Optimism testnet"),
-        }
+        write!(f, "{}", self.human_readable())
     }
 }

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+
+
+pub const POOL_ID_BITS: usize = 24;
+pub const GENERIC_ADDRESS_PREFIX: &str = "zkbob";
+
+
+// Here is a pool reference enum
+// It used to support multipool shielded addresses
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum Pool {
+    Polygon = 0,
+    Optimism,
+    Sepolia,
+    Goerli,
+    GoerliOptimism,
+}
+
+impl Pool {
+    pub fn from_pool_id(pool_id: u32) -> Option<Pool> {
+        match pool_id {
+            0x000000 => Some(Pool::Polygon),
+            0x000001 => Some(Pool::Optimism),
+            0x000002 => Some(Pool::Sepolia),
+            0xffff02 => Some(Pool::Goerli),
+            0xffff03 => Some(Pool::GoerliOptimism),
+            _ => None,
+        }
+    }
+
+    pub fn from_prefix(address_prefix: &str) -> Option<Pool> {
+        match address_prefix.to_lowercase().as_str() {
+            "zkbob_polygon" => Some(Pool::Polygon),
+            "zkbob_optimism" => Some(Pool::Optimism),
+            "zkbob_sepolia" => Some(Pool::Sepolia),
+            "zkbob_goerli" => Some(Pool::Goerli),
+            "zkbob_goerli_optimism" => Some(Pool::GoerliOptimism),
+            _ => None,
+        }
+    }
+
+    pub fn pool_id(&self) -> u32 {
+        match self {
+            Pool::Polygon => 0x00000,
+            Pool::Optimism => 0x00000,
+            Pool::Sepolia => 0x00000,
+            Pool::Goerli => 0xffff02,
+            Pool::GoerliOptimism => 0xffff03,
+        }
+    }
+
+    pub fn address_prefix(&self) -> &str {
+        match self {
+            Pool::Polygon => "zkbob_polygon",
+            Pool::Optimism => "zkbob_optimism",
+            Pool::Sepolia => "zkbob_sepolia",
+            Pool::Goerli => "zkbob_goerli",
+            Pool::GoerliOptimism => "zkbob_goerli_optimism",
+        }
+    }
+}
+
+impl fmt::Display for Pool {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Pool::Polygon => write!(f, "BOB on Polygon"),
+            Pool::Optimism => write!(f, "BOB on Optimism"),
+            Pool::Sepolia => write!(f, "BOB on Sepolia testnet"),
+            Pool::Goerli => write!(f, "BOB on Goerli testnet"),
+            Pool::GoerliOptimism => write!(f, "BOB on Goerli Optimism testnet"),
+        }
+    }
+}

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -25,7 +25,7 @@ impl Pool {
         match pool_id {
             0x000000 => Some(Pool::Polygon),
             0x000001 => Some(Pool::Optimism),
-            0x000002 => Some(Pool::Sepolia),
+            //0x000000 => Some(Pool::Sepolia),  // pool_id duplication, use this method with caution
             0xffff02 => Some(Pool::Goerli),
             0xffff03 => Some(Pool::GoerliOptimism),
             _ => None,
@@ -47,7 +47,7 @@ impl Pool {
         match self {
             Pool::Polygon => 0x000000,
             Pool::Optimism => 0x000001,
-            // here is an issue with Sepolia pool implementation
+            // here is an issue with Sepolia pool deployment
             Pool::Sepolia => 0x000000, 
             Pool::Goerli => 0xffff02,
             Pool::GoerliOptimism => 0xffff03,


### PR DESCRIPTION
The new addresses format description is here: https://www.notion.so/blockscout/Shielded-addresses-in-multipool-environment-a4f34585570240258575bb6ef59ee92a

Added routines to generate and parse universal addresses and checking address format. New functions are covered by unit-tests

Added pool catalog (pools.rs file). To support new pool it should be updated (currently supported: `BOB on Polygon`, `BOB on Optimism`, `ETH on Optimism` (not deployed yet), `BOB on Sepolia`, `BOB on Goerli`, `BOB on Goerli-Optimism`).

The old address format is supported on the BOB Polygon pool only


PRs chain:

- [libzkbob-rs/multipool-addresses](https://github.com/zkBob/libzkbob-rs/tree/multipool-addresses) --==>**you are here**<==--
- [zkbob-client-js/multipool-addresses ](https://github.com/zkBob/zkbob-client-js/tree/multipool-addresses) https://github.com/zkBob/zkbob-client-js/pull/117
- [zeropool-support-js/multipool-addresses](https://github.com/zkBob/zeropool-support-js/tree/multipool-addresses) https://github.com/zkBob/zeropool-support-js/pull/6
- [zkbob-console/multipool-addresses](https://github.com/zkBob/zkbob-console/tree/multipool-addresses) https://github.com/zkBob/zkbob-console/pull/69