### PR TITLE
New pools support

### DIFF
--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs-wasm"
 description = "A higher level zkBob API for Wasm"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs"
 description = "A higher level zkBob API"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -20,6 +20,8 @@ pub enum Pool {
     SepoliaBOB,
     GoerliBOB,
     GoerliOptimismBOB,
+    GoerliETH,
+    GoerliUSDC,
 }
 
 impl Pool {
@@ -33,6 +35,8 @@ impl Pool {
             //0x000000 => Some(Pool::SepoliaBOB),
             0xffff02 => Some(Pool::GoerliBOB),
             0xffff03 => Some(Pool::GoerliOptimismBOB),
+            0xffff04 => Some(Pool::GoerliETH),
+            0xffff05 => Some(Pool::GoerliUSDC),
             _ => None,
         }
     }
@@ -45,6 +49,8 @@ impl Pool {
             "zkbob_sepolia" => Some(Pool::SepoliaBOB),
             "zkbob_goerli" => Some(Pool::GoerliBOB),
             "zkbob_goerli_optimism" => Some(Pool::GoerliOptimismBOB),
+            "zkbob_goerli_eth" => Some(Pool::GoerliETH),
+            "zkbob_goerli_usdc" => Some(Pool::GoerliUSDC),
             _ => None,
         }
     }
@@ -58,6 +64,8 @@ impl Pool {
             Pool::SepoliaBOB => 0x000000, 
             Pool::GoerliBOB => 0xffff02,
             Pool::GoerliOptimismBOB => 0xffff03,
+            Pool::GoerliETH => 0xffff04,
+            Pool::GoerliUSDC => 0xffff05,
         }
     }
 
@@ -87,6 +95,8 @@ impl Pool {
             Pool::SepoliaBOB => "zkbob_sepolia",
             Pool::GoerliBOB => "zkbob_goerli",
             Pool::GoerliOptimismBOB => "zkbob_goerli_optimism",
+            Pool::GoerliETH => "zkbob_goerli_eth",
+            Pool::GoerliUSDC => "zkbob_goerli_usdc",
         }
     }
 
@@ -98,6 +108,8 @@ impl Pool {
             Pool::SepoliaBOB => "BOB on Sepolia testnet",
             Pool::GoerliBOB => "BOB on Goerli testnet",
             Pool::GoerliOptimismBOB => "BOB on Goerli Optimism testnet",
+            Pool::GoerliETH => "WETH on Goerli testnet",
+            Pool::GoerliUSDC => "USDC on Goerli testnet",
         }
     }
 }

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -17,6 +17,7 @@ pub enum Pool {
     PolygonBOB,
     OptimismBOB,
     OptimismETH,
+    PolygonUSDC,
     SepoliaBOB,
     GoerliBOB,
     GoerliOptimismBOB,
@@ -30,6 +31,7 @@ impl Pool {
             0x000000 => Some(Pool::PolygonBOB),
             0x000001 => Some(Pool::OptimismBOB),
             0x000002 => Some(Pool::OptimismETH),
+            0x000003 => Some(Pool::PolygonUSDC),
             // pool_id duplication, use this method with caution
             // (it will never produce Pool::SepoliaBOB object)
             //0x000000 => Some(Pool::SepoliaBOB),
@@ -46,6 +48,7 @@ impl Pool {
             "zkbob_polygon" => Some(Pool::PolygonBOB),
             "zkbob_optimism" => Some(Pool::OptimismBOB),
             "zkbob_optimism_eth" => Some(Pool::OptimismETH),
+            "zkbob_polygon_usdc" => Some(Pool::PolygonUSDC),
             "zkbob_sepolia" => Some(Pool::SepoliaBOB),
             "zkbob_goerli" => Some(Pool::GoerliBOB),
             "zkbob_goerli_optimism" => Some(Pool::GoerliOptimismBOB),
@@ -60,6 +63,7 @@ impl Pool {
             Pool::PolygonBOB => 0x000000,
             Pool::OptimismBOB => 0x000001,
             Pool::OptimismETH => 0x000002,
+            Pool::PolygonUSDC => 0x000003,
             // here is an issue with Sepolia pool deployment
             Pool::SepoliaBOB => 0x000000, 
             Pool::GoerliBOB => 0xffff02,
@@ -92,6 +96,7 @@ impl Pool {
             Pool::PolygonBOB => "zkbob_polygon",
             Pool::OptimismBOB => "zkbob_optimism",
             Pool::OptimismETH => "zkbob_optimism_eth",
+            Pool::PolygonUSDC => "zkbob_polygon_usdc",
             Pool::SepoliaBOB => "zkbob_sepolia",
             Pool::GoerliBOB => "zkbob_goerli",
             Pool::GoerliOptimismBOB => "zkbob_goerli_optimism",
@@ -104,7 +109,8 @@ impl Pool {
         match self {
             Pool::PolygonBOB => "BOB on Polygon",
             Pool::OptimismBOB => "BOB on Optimism",
-            Pool::OptimismETH => "ETH on Optimism",
+            Pool::OptimismETH => "WETH on Optimism",
+            Pool::PolygonUSDC => "USDC on Polygon",
             Pool::SepoliaBOB => "BOB on Sepolia testnet",
             Pool::GoerliBOB => "BOB on Goerli testnet",
             Pool::GoerliOptimismBOB => "BOB on Goerli Optimism testnet",


### PR DESCRIPTION
The following pools were added to support address prefixes

- poolId = `0xffff04`, address_prefix `zkbob_goerli_eth`
- poolId = `0xffff05`, address_prefix `zkbob_goerli_usdc`
- poolId = `0x000002`, address_prefix `zkbob_optimism_eth`
- poolId = `0x000003`, address_prefix `zkbob_polygon_usdc`