### PR TITLE
Fix db transaction timeout error on low resource devices by making explicit commit

### DIFF
--- a/libs/kvdb-web/src/indexed_db.rs
+++ b/libs/kvdb-web/src/indexed_db.rs
@@ -10,6 +10,7 @@
 
 use js_sys::{Array, ArrayBuffer, Uint8Array};
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
+use web_sys::console;
 use web_sys::{Event, IdbCursorWithValue, IdbDatabase, IdbKeyRange, IdbOpenDbRequest, IdbRequest, IdbTransactionMode};
 
 use futures::channel;
@@ -183,11 +184,13 @@ pub fn idb_commit_transaction(idb: &IdbDatabase, txn: &DBTransaction, columns: u
 	on_complete.forget();
 
 	let on_error = Closure::once(move || {
-		warn!("Failed to commit a transaction to IndexedDB");
+		console::error_1(&"Failed to commit a transaction to IndexedDB".into());
 	});
 	idb_txn.set_onerror(Some(on_error.as_ref().unchecked_ref()));
 	on_error.forget();
 
+	// Commit transaction explicitly to prevent timeout errors due to auto-commit delaying
+	idb_txn.commit().expect("IDBTransaction.commit failed");
 	rx.map(|_| ())
 }
 

--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs-wasm"
 description = "A higher level zkBob API for Wasm"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs"
 description = "A higher level zkBob API"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
As described in the [issue](https://github.com/zkBob/libzkbob-rs/issues/70) sometimes we have IndexedDB timeout errors. In this PR the explicit `IDBTransaction.commit` call was added to prevent such errors.

I tested our app (prod console) locally with Samsung Galaxy A51 and very often I was able to reproduce this error. After this change, the error was gone.

I also didn't find any performance issues with this solution.