### PR TITLE
Tron pools

### DIFF
--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs-wasm"
 description = "A higher level zkBob API for Wasm"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs"
 description = "A higher level zkBob API"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/src/address.rs
+++ b/libzkbob-rs/src/address.rs
@@ -125,7 +125,7 @@ pub fn parse_address_ext<P: PoolParams>(
         }
 
         // the old format should be acceptable on the Polygon BOB pool only
-        Ok((d, p_d, Some(Pool::PolygonBOB), AddressFormat::Old, checksum))
+        Ok((d, p_d, Some(Pool::PolygonUSDC), AddressFormat::Old, checksum))
     }
 }
 

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     fn test_create_tx_deposit_zero() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonUSDC, state, POOL_PARAMS.clone());
 
         acc.create_tx(
             TxType::Deposit(
@@ -666,7 +666,7 @@ mod tests {
     #[test]
     fn test_create_tx_deposit_one() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonUSDC, state, POOL_PARAMS.clone());
 
         acc.create_tx(
             TxType::Deposit(
@@ -684,7 +684,7 @@ mod tests {
     #[test]
     fn test_create_tx_transfer_zero() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonUSDC, state, POOL_PARAMS.clone());
 
         let addr = acc.generate_address();
 
@@ -705,7 +705,7 @@ mod tests {
     #[should_panic]
     fn test_create_tx_transfer_one_no_balance() {
         let state = State::init_test(POOL_PARAMS.clone());
-        let acc = UserAccount::new(Num::ZERO, Pool::PolygonBOB, state, POOL_PARAMS.clone());
+        let acc = UserAccount::new(Num::ZERO, Pool::PolygonUSDC, state, POOL_PARAMS.clone());
 
         let addr = acc.generate_address();
 
@@ -806,7 +806,7 @@ mod tests {
 
     #[test]
     fn test_chain_specific_addresses() {
-        let acc_polygon = UserAccount::new(Num::ZERO, Pool::PolygonBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc_polygon = UserAccount::new(Num::ZERO, Pool::PolygonUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
         let acc_sepolia = UserAccount::new(Num::ZERO, Pool::SepoliaBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
         let acc_optimism = UserAccount::new(Num::ZERO, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
         let acc_optimism_eth = UserAccount::new(Num::ZERO, Pool::OptimismETH, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
@@ -847,7 +847,7 @@ mod tests {
     #[test]
     fn test_chain_specific_address_ownable() {
         let accs = [
-            UserAccount::new(Num::ZERO, Pool::PolygonBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::PolygonUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
             UserAccount::new(Num::ZERO, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
             UserAccount::new(Num::ZERO, Pool::OptimismETH, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
             UserAccount::new(Num::ZERO, Pool::SepoliaBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -754,7 +754,7 @@ mod tests {
         let state = State::init_test(POOL_PARAMS.clone());
         let mut user_account = UserAccount::new(
             Num::ZERO,
-            Pool::OptimismBOB,
+            Pool::OptimismUSDC,
             state,
             POOL_PARAMS.clone()
         );
@@ -808,7 +808,7 @@ mod tests {
     fn test_chain_specific_addresses() {
         let acc_polygon = UserAccount::new(Num::ZERO, Pool::PolygonUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
         let acc_sepolia = UserAccount::new(Num::ZERO, Pool::SepoliaBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
-        let acc_optimism = UserAccount::new(Num::ZERO, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc_optimism = UserAccount::new(Num::ZERO, Pool::OptimismUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
         let acc_optimism_eth = UserAccount::new(Num::ZERO, Pool::OptimismETH, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
 
         assert!(acc_polygon.validate_address("PtfsqyJhA2yvmLtXBm55pkvFDX6XZrRMaib9F1GvwzmU8U4witUf8Jyse5kxBwa"));
@@ -848,13 +848,13 @@ mod tests {
     fn test_chain_specific_address_ownable() {
         let accs = [
             UserAccount::new(Num::ZERO, Pool::PolygonUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
-            UserAccount::new(Num::ZERO, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::OptimismUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
             UserAccount::new(Num::ZERO, Pool::OptimismETH, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
             UserAccount::new(Num::ZERO, Pool::SepoliaBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
             UserAccount::new(Num::ZERO, Pool::GoerliBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
-            UserAccount::new(Num::ZERO, Pool::GoerliOptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
+            UserAccount::new(Num::ZERO, Pool::GoerliOptimismUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone()),
         ];
-        let acc2 = UserAccount::new(Num::ONE, Pool::OptimismBOB, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
+        let acc2 = UserAccount::new(Num::ONE, Pool::OptimismUSDC, State::init_test(POOL_PARAMS.clone()), POOL_PARAMS.clone());
         let pool_addresses: Vec<String> = accs.iter().map(|acc| acc.generate_address()).collect();
         let universal_addresses: Vec<String> = accs.iter().map(|acc| acc.generate_universal_address()).collect();
 

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -15,12 +15,12 @@ pub const GENERIC_ADDRESS_PREFIX: &str = "zkbob";
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Pool {
     PolygonUSDC,
-    OptimismBOB,
+    OptimismUSDC,
     OptimismETH,
     TronUSDT,
     SepoliaBOB,
     GoerliBOB,
-    GoerliOptimismBOB,
+    GoerliOptimismUSDC,
     GoerliETH,
     GoerliUSDC,
     ShastaUSDT,
@@ -30,14 +30,14 @@ impl Pool {
     pub fn from_pool_id(pool_id: u32) -> Option<Pool> {
         match pool_id {
             0x000000 => Some(Pool::PolygonUSDC),
-            0x000001 => Some(Pool::OptimismBOB),
+            0x000001 => Some(Pool::OptimismUSDC),
             0x000002 => Some(Pool::OptimismETH),
             0x000003 => Some(Pool::TronUSDT),
             // pool_id duplication, use this method with caution
             // (it will never produce Pool::SepoliaBOB object)
             //0x000000 => Some(Pool::SepoliaBOB),
             0xffff02 => Some(Pool::GoerliBOB),
-            0xffff03 => Some(Pool::GoerliOptimismBOB),
+            0xffff03 => Some(Pool::GoerliOptimismUSDC),
             0xffff04 => Some(Pool::GoerliETH),
             0xffff05 => Some(Pool::GoerliUSDC),
             0xffff06 => Some(Pool::ShastaUSDT),
@@ -48,12 +48,12 @@ impl Pool {
     pub fn from_prefix(address_prefix: &str) -> Option<Pool> {
         match address_prefix.to_lowercase().as_str() {
             "zkbob_polygon" => Some(Pool::PolygonUSDC),
-            "zkbob_optimism" => Some(Pool::OptimismBOB),
+            "zkbob_optimism" => Some(Pool::OptimismUSDC),
             "zkbob_optimism_eth" => Some(Pool::OptimismETH),
             "zkbob_tron" => Some(Pool::TronUSDT),
             "zkbob_sepolia" => Some(Pool::SepoliaBOB),
             "zkbob_goerli" => Some(Pool::GoerliBOB),
-            "zkbob_goerli_optimism" => Some(Pool::GoerliOptimismBOB),
+            "zkbob_goerli_optimism" => Some(Pool::GoerliOptimismUSDC),
             "zkbob_goerli_eth" => Some(Pool::GoerliETH),
             "zkbob_goerli_usdc" => Some(Pool::GoerliUSDC),
             "zkbob_shasta" => Some(Pool::ShastaUSDT),
@@ -64,13 +64,13 @@ impl Pool {
     pub fn pool_id(&self) -> u32 {
         match self {
             Pool::PolygonUSDC => 0x000000,
-            Pool::OptimismBOB => 0x000001,
+            Pool::OptimismUSDC => 0x000001,
             Pool::OptimismETH => 0x000002,
             Pool::TronUSDT => 0x000003,
             // here is an issue with Sepolia pool deployment
             Pool::SepoliaBOB => 0x000000, 
             Pool::GoerliBOB => 0xffff02,
-            Pool::GoerliOptimismBOB => 0xffff03,
+            Pool::GoerliOptimismUSDC => 0xffff03,
             Pool::GoerliETH => 0xffff04,
             Pool::GoerliUSDC => 0xffff05,
             Pool::ShastaUSDT => 0xffff06,
@@ -98,12 +98,12 @@ impl Pool {
     pub fn address_prefix(&self) -> &str {
         match self {
             Pool::PolygonUSDC => "zkbob_polygon",
-            Pool::OptimismBOB => "zkbob_optimism",
+            Pool::OptimismUSDC => "zkbob_optimism",
             Pool::OptimismETH => "zkbob_optimism_eth",
             Pool::TronUSDT => "zkbob_tron",
             Pool::SepoliaBOB => "zkbob_sepolia",
             Pool::GoerliBOB => "zkbob_goerli",
-            Pool::GoerliOptimismBOB => "zkbob_goerli_optimism",
+            Pool::GoerliOptimismUSDC => "zkbob_goerli_optimism",
             Pool::GoerliETH => "zkbob_goerli_eth",
             Pool::GoerliUSDC => "zkbob_goerli_usdc",
             Pool::ShastaUSDT => "zkbob_shasta",
@@ -113,12 +113,12 @@ impl Pool {
     pub fn human_readable(&self) -> &str {
         match self {
             Pool::PolygonUSDC => "BOB on Polygon",
-            Pool::OptimismBOB => "BOB on Optimism",
+            Pool::OptimismUSDC => "USDC on Optimism",
             Pool::OptimismETH => "WETH on Optimism",
             Pool::TronUSDT => "USDT on Tron",
             Pool::SepoliaBOB => "BOB on Sepolia testnet",
             Pool::GoerliBOB => "BOB on Goerli testnet",
-            Pool::GoerliOptimismBOB => "BOB on Goerli Optimism testnet",
+            Pool::GoerliOptimismUSDC => "USDC on Goerli Optimism testnet",
             Pool::GoerliETH => "WETH on Goerli testnet",
             Pool::GoerliUSDC => "USDC on Goerli testnet",
             Pool::ShastaUSDT => "USDT on Shasta testnet",

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -14,24 +14,25 @@ pub const GENERIC_ADDRESS_PREFIX: &str = "zkbob";
 // It used to support multipool shielded addresses
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Pool {
-    PolygonBOB,
+    PolygonUSDC,
     OptimismBOB,
     OptimismETH,
-    PolygonUSDC,
+    TronUSDT,
     SepoliaBOB,
     GoerliBOB,
     GoerliOptimismBOB,
     GoerliETH,
     GoerliUSDC,
+    ShastaUSDT,
 }
 
 impl Pool {
     pub fn from_pool_id(pool_id: u32) -> Option<Pool> {
         match pool_id {
-            0x000000 => Some(Pool::PolygonBOB),
+            0x000000 => Some(Pool::PolygonUSDC),
             0x000001 => Some(Pool::OptimismBOB),
             0x000002 => Some(Pool::OptimismETH),
-            0x000003 => Some(Pool::PolygonUSDC),
+            0x000003 => Some(Pool::TronUSDT),
             // pool_id duplication, use this method with caution
             // (it will never produce Pool::SepoliaBOB object)
             //0x000000 => Some(Pool::SepoliaBOB),
@@ -39,37 +40,40 @@ impl Pool {
             0xffff03 => Some(Pool::GoerliOptimismBOB),
             0xffff04 => Some(Pool::GoerliETH),
             0xffff05 => Some(Pool::GoerliUSDC),
+            0xffff06 => Some(Pool::ShastaUSDT),
             _ => None,
         }
     }
 
     pub fn from_prefix(address_prefix: &str) -> Option<Pool> {
         match address_prefix.to_lowercase().as_str() {
-            "zkbob_polygon" => Some(Pool::PolygonBOB),
+            "zkbob_polygon" => Some(Pool::PolygonUSDC),
             "zkbob_optimism" => Some(Pool::OptimismBOB),
             "zkbob_optimism_eth" => Some(Pool::OptimismETH),
-            "zkbob_polygon_usdc" => Some(Pool::PolygonUSDC),
+            "zkbob_tron" => Some(Pool::TronUSDT),
             "zkbob_sepolia" => Some(Pool::SepoliaBOB),
             "zkbob_goerli" => Some(Pool::GoerliBOB),
             "zkbob_goerli_optimism" => Some(Pool::GoerliOptimismBOB),
             "zkbob_goerli_eth" => Some(Pool::GoerliETH),
             "zkbob_goerli_usdc" => Some(Pool::GoerliUSDC),
+            "zkbob_shasta" => Some(Pool::ShastaUSDT),
             _ => None,
         }
     }
 
     pub fn pool_id(&self) -> u32 {
         match self {
-            Pool::PolygonBOB => 0x000000,
+            Pool::PolygonUSDC => 0x000000,
             Pool::OptimismBOB => 0x000001,
             Pool::OptimismETH => 0x000002,
-            Pool::PolygonUSDC => 0x000003,
+            Pool::TronUSDT => 0x000003,
             // here is an issue with Sepolia pool deployment
             Pool::SepoliaBOB => 0x000000, 
             Pool::GoerliBOB => 0xffff02,
             Pool::GoerliOptimismBOB => 0xffff03,
             Pool::GoerliETH => 0xffff04,
             Pool::GoerliUSDC => 0xffff05,
+            Pool::ShastaUSDT => 0xffff06,
         }
     }
 
@@ -93,29 +97,31 @@ impl Pool {
 
     pub fn address_prefix(&self) -> &str {
         match self {
-            Pool::PolygonBOB => "zkbob_polygon",
+            Pool::PolygonUSDC => "zkbob_polygon",
             Pool::OptimismBOB => "zkbob_optimism",
             Pool::OptimismETH => "zkbob_optimism_eth",
-            Pool::PolygonUSDC => "zkbob_polygon_usdc",
+            Pool::TronUSDT => "zkbob_tron",
             Pool::SepoliaBOB => "zkbob_sepolia",
             Pool::GoerliBOB => "zkbob_goerli",
             Pool::GoerliOptimismBOB => "zkbob_goerli_optimism",
             Pool::GoerliETH => "zkbob_goerli_eth",
             Pool::GoerliUSDC => "zkbob_goerli_usdc",
+            Pool::ShastaUSDT => "zkbob_shasta",
         }
     }
 
     pub fn human_readable(&self) -> &str {
         match self {
-            Pool::PolygonBOB => "BOB on Polygon",
+            Pool::PolygonUSDC => "BOB on Polygon",
             Pool::OptimismBOB => "BOB on Optimism",
             Pool::OptimismETH => "WETH on Optimism",
-            Pool::PolygonUSDC => "USDC on Polygon",
+            Pool::TronUSDT => "USDT on Tron",
             Pool::SepoliaBOB => "BOB on Sepolia testnet",
             Pool::GoerliBOB => "BOB on Goerli testnet",
             Pool::GoerliOptimismBOB => "BOB on Goerli Optimism testnet",
             Pool::GoerliETH => "WETH on Goerli testnet",
             Pool::GoerliUSDC => "USDC on Goerli testnet",
+            Pool::ShastaUSDT => "USDT on Shasta testnet",
         }
     }
 }

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -112,7 +112,7 @@ impl Pool {
 
     pub fn human_readable(&self) -> &str {
         match self {
-            Pool::PolygonUSDC => "BOB on Polygon",
+            Pool::PolygonUSDC => "USDC on Polygon",
             Pool::OptimismUSDC => "USDC on Optimism",
             Pool::OptimismETH => "WETH on Optimism",
             Pool::TronUSDT => "USDT on Tron",


### PR DESCRIPTION
Added new tron pools:
- `zkbob_tron` => TronUSDT => `0x000003`
- `zkbob_shasta` => ShastaUSDT => `0xffff06`

Renamed Optimism pools (internal library enum members):
- `Pool::PolygonBOB` -> `Pool::PolygonUSDC`
- `Pool::OptimismBOB` -> `Pool::OptimismUSDC`
- `Pool::GoerliOptimismBOB` -> `Pool::GoerliOptimismUSDC`