### PR TITLE
Returning last nullifier from wasm library

### DIFF
--- a/libzkbob-rs-wasm/Cargo.toml
+++ b/libzkbob-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs-wasm"
 description = "A higher level zkBob API for Wasm"
-version = "1.4.2"
+version = "1.5.0"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/Cargo.toml
+++ b/libzkbob-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzkbob-rs"
 description = "A higher level zkBob API"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zkBob/libzkbob-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzkbob-rs/src/client/mod.rs
+++ b/libzkbob-rs/src/client/mod.rs
@@ -238,7 +238,7 @@ where
         cipher::decrypt_out(self.keys.eta, &data, &self.params)
     }
 
-    fn initial_account(&self) -> Account<P::Fr> {
+    pub fn initial_account(&self) -> Account<P::Fr> {
         // Initial account should have d = pool_id to protect from reply attacks
         let d = self.pool.pool_id_num().to_num();
         let p_d = derive_key_p_d(d, self.keys.eta, &self.params).x;

--- a/libzkbob-rs/src/pools.rs
+++ b/libzkbob-rs/src/pools.rs
@@ -24,6 +24,7 @@ pub enum Pool {
     GoerliETH,
     GoerliUSDC,
     ShastaUSDT,
+    NileUSDT,
 }
 
 impl Pool {
@@ -41,6 +42,7 @@ impl Pool {
             0xffff04 => Some(Pool::GoerliETH),
             0xffff05 => Some(Pool::GoerliUSDC),
             0xffff06 => Some(Pool::ShastaUSDT),
+            0xffff07 => Some(Pool::NileUSDT),
             _ => None,
         }
     }
@@ -57,6 +59,7 @@ impl Pool {
             "zkbob_goerli_eth" => Some(Pool::GoerliETH),
             "zkbob_goerli_usdc" => Some(Pool::GoerliUSDC),
             "zkbob_shasta" => Some(Pool::ShastaUSDT),
+            "zkbob_nile" => Some(Pool::NileUSDT),
             _ => None,
         }
     }
@@ -74,6 +77,7 @@ impl Pool {
             Pool::GoerliETH => 0xffff04,
             Pool::GoerliUSDC => 0xffff05,
             Pool::ShastaUSDT => 0xffff06,
+            Pool::NileUSDT => 0xffff07,
         }
     }
 
@@ -107,6 +111,7 @@ impl Pool {
             Pool::GoerliETH => "zkbob_goerli_eth",
             Pool::GoerliUSDC => "zkbob_goerli_usdc",
             Pool::ShastaUSDT => "zkbob_shasta",
+            Pool::NileUSDT => "zkbob_nile",
         }
     }
 
@@ -122,6 +127,7 @@ impl Pool {
             Pool::GoerliETH => "WETH on Goerli testnet",
             Pool::GoerliUSDC => "USDC on Goerli testnet",
             Pool::ShastaUSDT => "USDT on Shasta testnet",
+            Pool::NileUSDT => "USDT on Nile testnet",
         }
     }
 }


### PR DESCRIPTION
The following feature needed to support forced exit flow. The routine `accountNullifier` in the wasm lib returns the nullifier of the last account (or zero account nullifier is account doesn't exist yet)

The beta-version of the current branch are published with version `1.5.0-beta`

The associated PRs:
- https://github.com/zkBob/zkbob-client-js/pull/166
- https://github.com/zkBob/zkbob-console/pull/98